### PR TITLE
Fix find command line

### DIFF
--- a/bin/geninfo
+++ b/bin/geninfo
@@ -710,7 +710,7 @@ sub gen_info($)
 	{
 		info("Scanning $directory for $ext files ...\n");
 
-		@file_list = `find "$directory" $maxdepth $follow -name \\*$ext -type f -o -type l 2>/dev/null`;
+		@file_list = `find "$directory" $maxdepth $follow -name \\*$ext -type f -o -name \\*$ext -type l 2>/dev/null`;
 		chomp(@file_list);
 		if (!@file_list) {
 			warn("WARNING: no $ext files found in $directory - ".

--- a/bin/lcov
+++ b/bin/lcov
@@ -599,7 +599,7 @@ sub userspace_reset()
 	{
 		info("Deleting all .da files in $current_dir".
 		     ($no_recursion?"\n":" and subdirectories\n"));
-		@file_list = `find "$current_dir" $maxdepth $follow -name \\*\\.da -o -name \\*\\.gcda -type f 2>/dev/null`;
+		@file_list = `find "$current_dir" $maxdepth $follow -name \\*\\.da -type f -o -name \\*\\.gcda -type f 2>/dev/null`;
 		chomp(@file_list);
 		foreach (@file_list)
 		{


### PR DESCRIPTION
find xxx -name \*.gcda -type f -o type l
does return :
- all files with the .gcda suffix
- all symbolic links

the updated command line now returns
- all files with the .gcda suffix
- all symbolic links with the .gcda suffix

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>