### PR TITLE
Use UTC to get a timezone-independent date

### DIFF
--- a/bin/updateversion.pl
+++ b/bin/updateversion.pl
@@ -83,7 +83,7 @@ sub get_file_info($)
 
 	return (0, 0, 0) if (!-e $filename);
 	@stat = stat($filename);
-	($sec, $min, $hour, $day, $month, $year) = localtime($stat[9]);
+	($sec, $min, $hour, $day, $month, $year) = gmtime($stat[9]);
 	$year += 1900;
 	$month += 1;
 


### PR DESCRIPTION
The date is used for updating the time inside manpages.
If localtime is used, the date could vary depending on the user's
timezone. To enable reproducible builds, UTC is used instead.