### PR TITLE
lcov.spec: in files section appended wildcards to package only files

### DIFF
--- a/rpm/lcov.spec
+++ b/rpm/lcov.spec
@@ -31,9 +31,9 @@ rm -rf $RPM_BUILD_ROOT
 
 %files
 %defattr(-,root,root)
-/usr/bin
-/usr/share
-/etc
+/usr/bin/*
+/usr/share/man/man*/*.gz
+/etc/*
 
 %changelog
 * Mon May 07 2012 Peter Oberparleiter (Peter.Oberparleiter@de.ibm.com)


### PR DESCRIPTION
distributing /usr/bin and /usr/share/man folders are bad habit leading
to collision with mandatory packages

Signed-off-by: Jiri Kastner <jkastner@redhat.com>