### PR TITLE
Pass --no-strip-underscore to c++filt on OS X

### DIFF
--- a/bin/genhtml
+++ b/bin/genhtml
@@ -5325,6 +5325,7 @@ sub demangle_list($)
 	my $tmpfile;
 	my $handle;
 	my %demangle;
+    my $demangle_arg = "";
 	my %versions;
 
 	# Write function names to file
@@ -5333,8 +5334,14 @@ sub demangle_list($)
 	print($handle join("\n", @$list));
 	close($handle);
 
+    # Extra flag necessary on OS X so that symbols listed by gcov get demangled
+    # properly.
+    if ($^O eq "darwin") {
+        $demangle_arg = "--no-strip-underscores";
+    }
+
 	# Build translation hash from c++filt output
-	open($handle, "-|", "c++filt < $tmpfile") or
+	open($handle, "-|", "c++filt $demangle_arg < $tmpfile") or
 		die("ERROR: could not run c++filt: $!\n");
 	foreach my $func (@$list) {
 		my $translated = <$handle>;


### PR DESCRIPTION
* The --no-strip-underscope flag is necessary on OS X so that symbols
  listed by gcov get demangled properly.

   From the c++filt man page: "On some systems, both the C and C++
   compilers put an underscore in front of every name.  For example, the
   C name "foo" gets the low-level name "_foo". This option tells c++filt
   not to remove the initial underscore.  Whether c++filt removes the
   underscore by default is target dependent."

Signed-off-by: Benoit Belley <benoit.belley@autodesk.com>