### PR TITLE
lcov: speedup read_info_file

### DIFF
--- a/bin/lcov
+++ b/bin/lcov
@@ -1582,8 +1582,8 @@ sub br_ivec_len($)
 #
 # br_ivec_push(vector, block, branch, taken)
 #
-# Add an entry to the branch coverage vector. If an entry with the same
-# branch ID already exists, add the corresponding taken values.
+# Add an entry to the branch coverage vector. Entries with the same
+# branch ID might occur multiple times and must be added later
 #
 
 sub br_ivec_push($$$$)
@@ -1591,24 +1591,11 @@ sub br_ivec_push($$$$)
 	my ($vec, $block, $branch, $taken) = @_;
 	my $offset;
 	my $num = br_ivec_len($vec);
-	my $i;
 
 	$vec = "" if (!defined($vec));
 	$block = $BR_VEC_MAX if $block < 0;
 
-	# Check if branch already exists in vector
-	for ($i = 0; $i < $num; $i++) {
-		my ($v_block, $v_branch, $v_taken) = br_ivec_get($vec, $i);
-		$v_block = $BR_VEC_MAX if $v_block < 0;
-
-		next if ($v_block != $block || $v_branch != $branch);
-
-		# Add taken counts
-		$taken = br_taken_add($taken, $v_taken);
-		last;
-	}
-
-	$offset = $i * $BR_VEC_ENTRIES;
+	$offset = $num * $BR_VEC_ENTRIES;
 	$taken = br_taken_to_num($taken);
 
 	# Add to vector
@@ -1617,6 +1604,54 @@ sub br_ivec_push($$$$)
 	vec($vec, $offset + $BR_TAKEN, $BR_VEC_WIDTH) = $taken;
 
 	return $vec;
+}
+
+#
+# br_ihash_push(line, block, branch, taken, hash-reference)
+#
+# Add an entry from the branch coverage vector to an hash.
+# If an entry with the same branch ID already exists, add the corresponding
+# taken values.
+#
+
+sub br_ihash_push($$$$$)
+{
+	my ($line, $block, $branch, $taken, $hashref) = @_;
+
+	#TODO do we need that?
+	$block = $BR_VEC_MAX if $block < 0;
+
+	# Check if branch already exists in hash
+	# don't do the following:
+	#     if (exists $hash{$block}{$branch}) {
+	# since it might lead to autovivification: https://perlmaven.com/autovivification
+	# thus the pure test for existence will create at least an entry in $hash with
+	# the given $block as key!
+	if (exists $hashref->{$line}) {
+		if (exists $hashref->{$line}{$block}) {
+			if (exists $hashref->{$line}{$block}{$branch}) {
+				my $v_taken = $hashref->{$line}{$block}{$branch};
+				# Add taken counts
+				$taken = br_taken_add($taken, $v_taken);
+			}
+		}
+	}
+
+	$taken = $taken;
+
+	# Add to hash
+	$hashref->{$line}{$block}{$branch} = $taken;
+}
+
+sub br_ivec_squash($){
+	my $vec = $_[0];
+	my %hash;
+	if(defined($vec)) {
+		%hash = %{brcount_to_db($vec)};
+	}
+	($vec, undef, undef) = db_to_brcount(\%hash);
+
+	return $vec
 }
 
 
@@ -1965,6 +2000,31 @@ sub read_info_file($)
 		}
 	}
 	close(INFO_HANDLE);
+
+	# squash the branch vectors in a way that they will contain only one entry
+	# per branch id afterwrds.
+	foreach $filename (keys %result) {
+		$data = $result{$filename};
+		($testdata, $sumcount, $funcdata, $checkdata,
+			 $testfncdata, $sumfnccount, $testbrdata,
+			 $sumbrcount) =
+		get_info_entry($data);
+
+		$sumbrcount = br_ivec_squash($sumbrcount);
+
+		my $testname;
+		foreach $testname (keys %{$testbrdata}) {
+			$testbrdata->{$testname} = br_ivec_squash($testbrdata->{$testname});
+		}
+
+		set_info_entry($data, $testdata,
+								$sumcount, $funcdata,
+							   $checkdata, $testfncdata,
+							   $sumfnccount,
+							   $testbrdata,
+							   $sumbrcount);
+		$result{$filename} = $data;
+	}
 
 	# Calculate hit and found values for lines and functions of each file
 	foreach $filename (keys(%result))
@@ -2316,7 +2376,8 @@ sub brcount_to_db($)
 {
 	my ($brcount) = @_;
 	my $line;
-	my $db;
+	my %hash;
+	my $db = \%hash;
 
 	# Add branches from first count to database
 	foreach $line (keys(%{$brcount})) {
@@ -2327,7 +2388,7 @@ sub brcount_to_db($)
 		for ($i = 0; $i < $num; $i++) {
 			my ($block, $branch, $taken) = br_ivec_get($brdata, $i);
 
-			$db->{$line}->{$block}->{$branch} = $taken;
+			br_ihash_push($line, $block, $branch, $taken, $db);
 		}
 	}
 


### PR DESCRIPTION
As mentioned in https://github.com/linux-test-project/lcov/issues/5 read_info_file
might get extremely slow on large projects/info-files.
The root cause was a loop through every vector entry on each br_ivec_push(). To
increase speed on this operation, i just skip this check during the initial file
read. That way entries with the same branch id might occure multiple times and thus
have to be squashed together afterwards.
To squash it afterwards makes the process way faster, since it only has to run
through the whole vector only once. During that process, parts of the vector are
put into a hash, which performs very fast. I only put parts of the vector into the
hash to keep the memory footprint as low as possible.

Signed-off-by: Christian Reich <creich@linux.com>