### PR TITLE
Adding the --include and --exclude options to lcov and geninfo

### DIFF
--- a/bin/geninfo
+++ b/bin/geninfo
@@ -240,8 +240,8 @@ our $config;		# Configuration file contents
 our @ignore_errors;	# List of errors to ignore (parameter)
 our @ignore;		# List of errors to ignore (array)
 our $initial;
-our @extract_patterns; # List of source file patterns to extract
-our @ignore_patterns; # List of source file patterns to ignore
+our @include_patterns; # List of source file patterns to include
+our @exclude_patterns; # List of source file patterns to exclude
 our $no_recursion = 0;
 our $maxdepth;
 our $no_markers = 0;
@@ -385,8 +385,8 @@ if (!GetOptions("test-name|t=s" => \$test_name,
 		"gcov-tool=s" => \$gcov_tool,
 		"ignore-errors=s" => \@ignore_errors,
         "initial|i" => \$initial,
-        "extract=s" => \@extract_patterns,
-        "ignore=s" => \@ignore_patterns,
+        "include=s" => \@include_patterns,
+        "exclude=s" => \@exclude_patterns,
 		"no-recursion" => \$no_recursion,
 		"no-markers" => \$no_markers,
 		"derive-func-data" => \$opt_derive_func_data,
@@ -421,14 +421,14 @@ else
 		$opt_no_external = undef;
 	}
 
-    if(@extract_patterns) {
+    if(@include_patterns) {
         # Need perlreg expressions instead of shell pattern
-        @extract_patterns = map({ transform_pattern($_); } @extract_patterns);
+        @include_patterns = map({ transform_pattern($_); } @include_patterns);
     }
 
-    if(@ignore_patterns) {
+    if(@exclude_patterns) {
         # Need perlreg expressions instead of shell pattern
-        @ignore_patterns = map({ transform_pattern($_); } @ignore_patterns);
+        @exclude_patterns = map({ transform_pattern($_); } @exclude_patterns);
     }
 }
 
@@ -637,8 +637,8 @@ sequentially.
       --config-file FILENAME        Specify configuration file location
       --rc SETTING=VALUE            Override configuration file setting
       --compat MODE=on|off|auto     Set compat MODE (libtool, hammer, split_crc)
-      --extract PATTERN             Extract files matching PATTERN
-      --ignore PATTERN              Ignore files matching PATTERN
+      --include PATTERN             Include files matching PATTERN
+      --exclude PATTERN             Exclude files matching PATTERN
 
 For more information see: $lcov_url
 END_OF_USAGE
@@ -1200,11 +1200,11 @@ sub process_dafile($$)
 			next;
 		}
 
-        if (@extract_patterns)
+        if (@include_patterns)
         {
             my $keep = 0;
 
-            foreach my $pattern (@extract_patterns)
+            foreach my $pattern (@include_patterns)
             {
                 $keep ||= ($source =~ (/^$pattern$/));
             }
@@ -1216,16 +1216,16 @@ sub process_dafile($$)
             }
         }
 
-        if (@ignore_patterns)
+        if (@exclude_patterns)
         {
-            my $ignore = 0;
+            my $exclude = 0;
 
-            foreach my $pattern (@ignore_patterns)
+            foreach my $pattern (@exclude_patterns)
             {
-                $ignore ||= ($source =~ (/^$pattern$/));
+                $exclude ||= ($source =~ (/^$pattern$/));
             }
 
-            if ($ignore)
+            if ($exclude)
             {
                 unlink($gcov_file);
                 next;

--- a/bin/geninfo
+++ b/bin/geninfo
@@ -151,6 +151,7 @@ our $UNNAMED_BLOCK	= -1;
 
 # Prototypes
 sub print_usage(*);
+sub transform_pattern($);
 sub gen_info($);
 sub process_dafile($$);
 sub match_filename($@);
@@ -239,6 +240,8 @@ our $config;		# Configuration file contents
 our @ignore_errors;	# List of errors to ignore (parameter)
 our @ignore;		# List of errors to ignore (array)
 our $initial;
+our @extract_patterns; # List of source file patterns to extract
+our @ignore_patterns; # List of source file patterns to ignore
 our $no_recursion = 0;
 our $maxdepth;
 our $no_markers = 0;
@@ -381,12 +384,14 @@ if (!GetOptions("test-name|t=s" => \$test_name,
 		"no-compat-libtool" => \$opt_no_compat_libtool,
 		"gcov-tool=s" => \$gcov_tool,
 		"ignore-errors=s" => \@ignore_errors,
-		"initial|i" => \$initial,
+        "initial|i" => \$initial,
+        "extract=s" => \@extract_patterns,
+        "ignore=s" => \@ignore_patterns,
 		"no-recursion" => \$no_recursion,
 		"no-markers" => \$no_markers,
 		"derive-func-data" => \$opt_derive_func_data,
 		"debug" => \$debug,
-		"external" => \$opt_external,
+		"external|e" => \$opt_external,
 		"no-external" => \$opt_no_external,
 		"compat=s" => \$opt_compat,
 		"config-file=s" => \$opt_config_file,
@@ -415,6 +420,16 @@ else
 		$opt_external = 0;
 		$opt_no_external = undef;
 	}
+
+    if(@extract_patterns) {
+        # Need perlreg expressions instead of shell pattern
+        @extract_patterns = map({ transform_pattern($_); } @extract_patterns);
+    }
+
+    if(@ignore_patterns) {
+        # Need perlreg expressions instead of shell pattern
+        @ignore_patterns = map({ transform_pattern($_); } @ignore_patterns);
+    }
 }
 
 @data_directory = @ARGV;
@@ -622,11 +637,52 @@ sequentially.
       --config-file FILENAME        Specify configuration file location
       --rc SETTING=VALUE            Override configuration file setting
       --compat MODE=on|off|auto     Set compat MODE (libtool, hammer, split_crc)
+      --extract PATTERN             Extract files matching PATTERN
+      --ignore PATTERN              Ignore files matching PATTERN
 
 For more information see: $lcov_url
 END_OF_USAGE
 	;
 }
+
+
+#
+# transform_pattern(pattern)
+#
+# Transform shell wildcard expression to equivalent Perl regular expression.
+# Return transformed pattern.
+#
+
+sub transform_pattern($)
+{
+	my $pattern = $_[0];
+
+	# Escape special chars
+
+	$pattern =~ s/\\/\\\\/g;
+	$pattern =~ s/\//\\\//g;
+	$pattern =~ s/\^/\\\^/g;
+	$pattern =~ s/\$/\\\$/g;
+	$pattern =~ s/\(/\\\(/g;
+	$pattern =~ s/\)/\\\)/g;
+	$pattern =~ s/\[/\\\[/g;
+	$pattern =~ s/\]/\\\]/g;
+	$pattern =~ s/\{/\\\{/g;
+	$pattern =~ s/\}/\\\}/g;
+	$pattern =~ s/\./\\\./g;
+	$pattern =~ s/\,/\\\,/g;
+	$pattern =~ s/\|/\\\|/g;
+	$pattern =~ s/\+/\\\+/g;
+	$pattern =~ s/\!/\\\!/g;
+
+	# Transform ? => (.) and * => (.*)
+
+	$pattern =~ s/\*/\(\.\*\)/g;
+	$pattern =~ s/\?/\(\.\)/g;
+
+	return $pattern;
+}
+
 
 #
 # get_common_prefix(min_dir, filenames)
@@ -1143,6 +1199,38 @@ sub process_dafile($$)
 			unlink($gcov_file);
 			next;
 		}
+
+        if (@extract_patterns)
+        {
+            my $keep = 0;
+
+            foreach my $pattern (@extract_patterns)
+            {
+                $keep ||= ($source =~ (/^$pattern$/));
+            }
+
+            if (!$keep)
+            {
+                unlink($gcov_file);
+                next;
+            }
+        }
+
+        if (@ignore_patterns)
+        {
+            my $ignore = 0;
+
+            foreach my $pattern (@ignore_patterns)
+            {
+                $ignore ||= ($source =~ (/^$pattern$/));
+            }
+
+            if ($ignore)
+            {
+                unlink($gcov_file);
+                next;
+            }
+        }
 
 		# Read in contents of gcov file
 		@result = read_gcov_file($gcov_file);

--- a/bin/geninfo
+++ b/bin/geninfo
@@ -384,9 +384,9 @@ if (!GetOptions("test-name|t=s" => \$test_name,
 		"no-compat-libtool" => \$opt_no_compat_libtool,
 		"gcov-tool=s" => \$gcov_tool,
 		"ignore-errors=s" => \@ignore_errors,
-        "initial|i" => \$initial,
-        "include=s" => \@include_patterns,
-        "exclude=s" => \@exclude_patterns,
+		"initial|i" => \$initial,
+		"include=s" => \@include_patterns,
+		"exclude=s" => \@exclude_patterns,
 		"no-recursion" => \$no_recursion,
 		"no-markers" => \$no_markers,
 		"derive-func-data" => \$opt_derive_func_data,
@@ -421,15 +421,15 @@ else
 		$opt_no_external = undef;
 	}
 
-    if(@include_patterns) {
-        # Need perlreg expressions instead of shell pattern
-        @include_patterns = map({ transform_pattern($_); } @include_patterns);
-    }
+	if(@include_patterns) {
+		# Need perlreg expressions instead of shell pattern
+		@include_patterns = map({ transform_pattern($_); } @include_patterns);
+	}
 
-    if(@exclude_patterns) {
-        # Need perlreg expressions instead of shell pattern
-        @exclude_patterns = map({ transform_pattern($_); } @exclude_patterns);
-    }
+	if(@exclude_patterns) {
+		# Need perlreg expressions instead of shell pattern
+		@exclude_patterns = map({ transform_pattern($_); } @exclude_patterns);
+	}
 }
 
 @data_directory = @ARGV;
@@ -637,8 +637,6 @@ sequentially.
       --config-file FILENAME        Specify configuration file location
       --rc SETTING=VALUE            Override configuration file setting
       --compat MODE=on|off|auto     Set compat MODE (libtool, hammer, split_crc)
-      --include PATTERN             Include files matching PATTERN
-      --exclude PATTERN             Exclude files matching PATTERN
 
 For more information see: $lcov_url
 END_OF_USAGE
@@ -1200,38 +1198,6 @@ sub process_dafile($$)
 			next;
 		}
 
-        if (@include_patterns)
-        {
-            my $keep = 0;
-
-            foreach my $pattern (@include_patterns)
-            {
-                $keep ||= ($source =~ (/^$pattern$/));
-            }
-
-            if (!$keep)
-            {
-                unlink($gcov_file);
-                next;
-            }
-        }
-
-        if (@exclude_patterns)
-        {
-            my $exclude = 0;
-
-            foreach my $pattern (@exclude_patterns)
-            {
-                $exclude ||= ($source =~ (/^$pattern$/));
-            }
-
-            if ($exclude)
-            {
-                unlink($gcov_file);
-                next;
-            }
-        }
-
 		# Read in contents of gcov file
 		@result = read_gcov_file($gcov_file);
 		if (!defined($result[0])) {
@@ -1262,6 +1228,40 @@ sub process_dafile($$)
 			# Try to solve the ambiguity
 			$source_filename = solve_ambiguous_match($gcov_file,
 						\@matches, \@gcov_content);
+		}
+
+		if (@include_patterns)
+		{
+			my $keep = 0;
+
+			foreach my $pattern (@include_patterns)
+			{
+				$keep ||= ($source_filename =~ (/^$pattern$/));
+			}
+
+			if (!$keep)
+			{
+				info("	not included: $source_filename\n");
+				unlink($gcov_file);
+				next;
+			}
+		}
+
+		if (@exclude_patterns)
+		{
+			my $exclude = 0;
+
+			foreach my $pattern (@exclude_patterns)
+			{
+				$exclude ||= ($source_filename =~ (/^$pattern$/));
+			}
+
+			if ($exclude)
+			{
+				info("	excluded: $source_filename\n");
+				unlink($gcov_file);
+				next;
+			}
 		}
 
 		# Skip external files if requested

--- a/bin/lcov
+++ b/bin/lcov
@@ -283,8 +283,8 @@ if (!GetOptions("directory|d|di=s" => \@directory,
 		"gcov-tool=s" => \$gcov_tool,
 		"ignore-errors=s" => \@opt_ignore_errors,
 		"initial|i" => \$initial,
-        "include=s" => \@include_patterns,
-        "exclude=s" => \@exclude_patterns,
+		"include=s" => \@include_patterns,
+		"exclude=s" => \@exclude_patterns,
 		"no-recursion" => \$no_recursion,
 		"to-package=s" => \$to_package,
 		"from-package=s" => \$from_package,
@@ -542,8 +542,6 @@ Options:
       --config-file FILENAME      Specify configuration file location
       --rc SETTING=VALUE          Override configuration file setting
       --compat MODE=on|off|auto   Set compat MODE (libtool, hammer, split_crc)
-      --include PATTERN           Include files matching PATTERN
-      --exclude PATTERN           Exclude files matching PATTERN
 
 For more information see: $lcov_url
 END_OF_USAGE

--- a/bin/lcov
+++ b/bin/lcov
@@ -166,6 +166,8 @@ our $no_compat_libtool;	# If set, indicates that libtool mode is to be disabled
 our $gcov_tool;
 our @opt_ignore_errors;
 our $initial;
+our @include_patterns; # List of source file patterns to include
+our @exclude_patterns; # List of source file patterns to exclude
 our $no_recursion = 0;
 our $to_package;
 our $from_package;
@@ -281,6 +283,8 @@ if (!GetOptions("directory|d|di=s" => \@directory,
 		"gcov-tool=s" => \$gcov_tool,
 		"ignore-errors=s" => \@opt_ignore_errors,
 		"initial|i" => \$initial,
+        "include=s" => \@include_patterns,
+        "exclude=s" => \@exclude_patterns,
 		"no-recursion" => \$no_recursion,
 		"to-package=s" => \$to_package,
 		"from-package=s" => \$from_package,
@@ -538,6 +542,8 @@ Options:
       --config-file FILENAME      Specify configuration file location
       --rc SETTING=VALUE          Override configuration file setting
       --compat MODE=on|off|auto   Set compat MODE (libtool, hammer, split_crc)
+      --include PATTERN           Include files matching PATTERN
+      --exclude PATTERN           Exclude files matching PATTERN
 
 For more information see: $lcov_url
 END_OF_USAGE
@@ -884,6 +890,12 @@ sub lcov_geninfo(@)
 	}
 	if (defined($opt_config_file)) {
 		@param = (@param, "--config-file", $opt_config_file);
+	}
+	foreach (@include_patterns) {
+		@param = (@param, "--include", $_);
+	}
+	foreach (@exclude_patterns) {
+		@param = (@param, "--exclude", $_);
 	}
 
 	system(@param) and exit($? >> 8);

--- a/man/geninfo.1
+++ b/man/geninfo.1
@@ -295,7 +295,7 @@ information about which lines belong to a function.
 .I pattern
 .br
 .RS
-Exclude data from source files matching
+Exclude source files matching
 .IR pattern .
 
 Use this switch if you want to exclude coverage data for a particular set
@@ -355,7 +355,7 @@ Print a short help text, then exit.
 .I pattern
 .br
 .RS
-Include data from source files matching
+Include source files matching
 .IR pattern .
 
 Use this switch if you want to include coverage data for only a particular set

--- a/man/geninfo.1
+++ b/man/geninfo.1
@@ -46,9 +46,9 @@ geninfo \- Generate tracefiles from .da files
 .RB [ \-\-rc
 .IR keyword = value ]
 .br
-.RB [ \-\-extract
+.RB [ \-\-include
 .IR pattern ]
-.RB [ \-\-ignore
+.RB [ \-\-exclude
 .IR pattern ]
 .RE
 .SH DESCRIPTION
@@ -291,6 +291,28 @@ instead derive function coverage data from line coverage data and
 information about which lines belong to a function.
 .RE
 
+.B \-\-exclude
+.I pattern
+.br
+.RS
+Exclude data from source files matching
+.IR pattern .
+
+Use this switch if you want to exclude coverage data for a particular set
+of source files matching any of the given patterns. Multiple patterns can be
+specified by using multiple
+.B --exclude
+command line switches. The
+.I patterns
+will be interpreted as shell wildcard patterns (note that they may need to be
+escaped accordingly to prevent the shell from expanding them first).
+
+Can be combined with the
+.B --include
+command line switch. If a given file matches both the include pattern and the
+exclude pattern, the exclude pattern will take precedence.
+.RE
+
 .B \-\-external
 .br
 .B \-\-no\-external
@@ -306,45 +328,6 @@ ignore this data.
 Data for external source files is
 .B included
 by default.
-.RE
-
-.B \-\-extract
-.I pattern
-.br
-.RS
-Extract data from source files matching
-.IR pattern .
-
-Use this switch if you want to extract coverage data for only a particular set
-of source files matching any of the given patterns. Multiple patterns can be
-specified by using multiple
-.B --extract
-command line switches. The
-.I patterns
-will be interpreted as shell wildcard patterns (note that they may need to be
-escaped accordingly to prevent the shell from expanding them first).
-.RE
-
-.B \-\-ignore
-.I pattern
-.br
-.RS
-Ignore data from source files matching
-.IR pattern .
-
-Use this switch if you want to ignore coverage data for a particular set
-of source files matching any of the given patterns. Multiple patterns can be
-specified by using multiple
-.B --ignore
-command line switches. The
-.I patterns
-will be interpreted as shell wildcard patterns (note that they may need to be
-escaped accordingly to prevent the shell from expanding them first).
-
-Can be combined with the
-.B --extract
-command line switch. If a given file matches both the extract pattern and the
-ignore pattern, the ignore pattern will take precedence.
 .RE
 
 .B \-f
@@ -366,6 +349,23 @@ Specify the location of the gcov tool.
 .B \-\-help
 .RS
 Print a short help text, then exit.
+.RE
+
+.B \-\-include
+.I pattern
+.br
+.RS
+Include data from source files matching
+.IR pattern .
+
+Use this switch if you want to include coverage data for only a particular set
+of source files matching any of the given patterns. Multiple patterns can be
+specified by using multiple
+.B --include
+command line switches. The
+.I patterns
+will be interpreted as shell wildcard patterns (note that they may need to be
+escaped accordingly to prevent the shell from expanding them first).
 .RE
 
 .B \-\-ignore\-errors

--- a/man/geninfo.1
+++ b/man/geninfo.1
@@ -45,6 +45,11 @@ geninfo \- Generate tracefiles from .da files
 .br
 .RB [ \-\-rc
 .IR keyword = value ]
+.br
+.RB [ \-\-extract
+.IR pattern ]
+.RB [ \-\-ignore
+.IR pattern ]
 .RE
 .SH DESCRIPTION
 .B geninfo 
@@ -301,6 +306,45 @@ ignore this data.
 Data for external source files is
 .B included
 by default.
+.RE
+
+.B \-\-extract
+.I pattern
+.br
+.RS
+Extract data from source files matching
+.IR pattern .
+
+Use this switch if you want to extract coverage data for only a particular set
+of source files matching any of the given patterns. Multiple patterns can be
+specified by using multiple
+.B --extract
+command line switches. The
+.I patterns
+will be interpreted as shell wildcard patterns (note that they may need to be
+escaped accordingly to prevent the shell from expanding them first).
+.RE
+
+.B \-\-ignore
+.I pattern
+.br
+.RS
+Ignore data from source files matching
+.IR pattern .
+
+Use this switch if you want to ignore coverage data for a particular set
+of source files matching any of the given patterns. Multiple patterns can be
+specified by using multiple
+.B --ignore
+command line switches. The
+.I patterns
+will be interpreted as shell wildcard patterns (note that they may need to be
+escaped accordingly to prevent the shell from expanding them first).
+
+Can be combined with the
+.B --extract
+command line switch. If a given file matches both the extract pattern and the
+ignore pattern, the ignore pattern will take precedence.
 .RE
 
 .B \-f

--- a/man/lcov.1
+++ b/man/lcov.1
@@ -50,6 +50,11 @@ lcov \- a graphical GCOV front\-end
 .RB [ \-\-compat
 .IR  mode =on|off|auto]
 .br
+.RB [ \-\-include
+.IR pattern ]
+.RB [ \-\-exclude
+.IR pattern ]
+.br
 .RE
 
 .B lcov
@@ -476,6 +481,28 @@ where the counter files ending with .da will be stored).
 Note that you may specify this option more than once.
 .RE
 
+.B \-\-exclude
+.I pattern
+.br
+.RS
+Exclude data from source files matching
+.IR pattern .
+
+Use this switch if you want to exclude coverage data for a particular set
+of source files matching any of the given patterns. Multiple patterns can be
+specified by using multiple
+.B --exclude
+command line switches. The
+.I patterns
+will be interpreted as shell wildcard patterns (note that they may need to be
+escaped accordingly to prevent the shell from expanding them first).
+
+Can be combined with the
+.B --include
+command line switch. If a given file matches both the include pattern and the
+exclude pattern, the exclude pattern will take precedence.
+.RE
+
 .B \-\-external
 .br
 .B \-\-no\-external
@@ -554,6 +581,23 @@ Specify the location of the gcov tool.
 .br
 .RS
 Print a short help text, then exit.
+.RE
+
+.B \-\-include
+.I pattern
+.br
+.RS
+Include data from source files matching
+.IR pattern .
+
+Use this switch if you want to include coverage data for only a particular set
+of source files matching any of the given patterns. Multiple patterns can be
+specified by using multiple
+.B --include
+command line switches. The
+.I patterns
+will be interpreted as shell wildcard patterns (note that they may need to be
+escaped accordingly to prevent the shell from expanding them first).
 .RE
 
 .B \-\-ignore\-errors

--- a/man/lcov.1
+++ b/man/lcov.1
@@ -485,7 +485,7 @@ Note that you may specify this option more than once.
 .I pattern
 .br
 .RS
-Exclude data from source files matching
+Exclude source files matching
 .IR pattern .
 
 Use this switch if you want to exclude coverage data for a particular set
@@ -587,7 +587,7 @@ Print a short help text, then exit.
 .I pattern
 .br
 .RS
-Include data from source files matching
+Include source files matching
 .IR pattern .
 
 Use this switch if you want to include coverage data for only a particular set


### PR DESCRIPTION
* The --include command-line option allows the user to specify a regular
  expression for the source files to be included. The command-line
  option can be repeated to specify multiple patterns. The coverage
  information is only included for the source files matching at least
  one of the patterns.

  The "lcov --capture --include" (or "geninfo --include") option is
  similar in functionality to the "lcov --extract" command-line
  option. But, by directly using applying the pattern while capturing
  coverage data one can often avoid having to run "lcov --extract" as a
  second pass.

* The --exclude command-line option allows the user to specify a regular
  expression for the source files to be excluded. The command-line
  option can be repeated to specify multiple patterns. The coverage
  information is excluded for source files matching at least one of the
  patterns.

  The "lcov --capture --exclude" (or "geninfo --exclude") option is
  similar in functionality to the "lcov --extract" command-line
  option. But, by directly using applying the pattern while capturing
  coverage data one can often avoid having to run "lcov --remove" as a
  second pass.

* On one of our code base at Autodesk, this speeds-up the generation of
  HTML code coverage reports by a factor of 3X.

Signed-off-by: Benoit Belley <benoit.belley@autodesk.com>