### PR TITLE
geninfo: preserve-paths makes gcov to fail for long pathnames

### DIFF
--- a/bin/geninfo
+++ b/bin/geninfo
@@ -468,7 +468,12 @@ push(@gcov_options, "-c") if ($gcov_caps->{'branch-counts'} &&
 			      $br_coverage);
 push(@gcov_options, "-a") if ($gcov_caps->{'all-blocks'} &&
 			      $opt_gcov_all_blocks && $br_coverage);
-push(@gcov_options, "-p") if ($gcov_caps->{'preserve-paths'});
+if ($gcov_caps->{'hash-filenames'})
+{
+    push(@gcov_options, "-x");
+} else {
+    push(@gcov_options, "-p") if ($gcov_caps->{'preserve-paths'});
+}
 
 # Determine compatibility modes
 parse_compat_modes($opt_compat);
@@ -3775,6 +3780,7 @@ sub get_gcov_capabilities()
 		'p' => 'preserve-paths',
 		'u' => 'unconditional-branches',
 		'v' => 'version',
+		'x' => 'hash-filenames',
 	);
 
 	foreach (split(/\n/, $help)) {


### PR DESCRIPTION
geninfo uses '--preserve-paths' gcov option whenever gcov supports it, this
forces gcov to use a whole pathname as a filename for .gcov files. So in cases
of quite large pathnames, gcov isn't able to create .gcov files and hence
geninfo can't get any data. The fix removes '--preserve-paths'.

Signed-off-by: Igor Ignatev <igor.v.ignatiev@gmail.com>