### PR TITLE
genhtml: Fix applying prefix to a prefix filename

### DIFF
--- a/bin/genhtml
+++ b/bin/genhtml
@@ -5656,6 +5656,10 @@ sub apply_prefix($@)
 	{
 		foreach my $prefix (@dir_prefix)
 		{
+			if ($prefix eq $filename)
+			{
+				return "root";
+			}
 			if ($prefix ne "" && $filename =~ /^\Q$prefix\E\/(.*)$/)
 			{
 				return substr($filename, length($prefix) + 1);


### PR DESCRIPTION
Currently, if you have source code that lives in the top-level of your
project but you have that top-level set as a prefix, genhtml will not do
anything to truncate the prefix for the directory link.

Assume genhtml is called with `--prefix /home/wak/project`
Example layout:
/home/wak/project/lib.cpp
/home/wak/project/test/test_lib.cpp

This would result in generating an index.html with Directories:
/home/wak/project
test

This is not expected. Looking at the convention for top level
directories, we should be calling these directories "root".

With the patch applied, the index.html has Directories:
root
test