### PR TITLE
bin: remove oudated FSF mailing address from license boilerplate

### DIFF
--- a/bin/gendesc
+++ b/bin/gendesc
@@ -13,8 +13,8 @@
 #   General Public License for more details.                 
 #
 #   You should have received a copy of the GNU General Public License
-#   along with this program;  if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+#   along with this program;  if not, see
+#   <http://www.gnu.org/licenses/>.
 #
 #
 # gendesc

--- a/bin/genhtml
+++ b/bin/genhtml
@@ -13,8 +13,8 @@
 #   General Public License for more details. 
 #
 #   You should have received a copy of the GNU General Public License
-#   along with this program;  if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+#   along with this program;  if not, see
+#   <http://www.gnu.org/licenses/>.
 #
 #
 # genhtml

--- a/bin/geninfo
+++ b/bin/geninfo
@@ -13,8 +13,8 @@
 #   General Public License for more details.                 
 #
 #   You should have received a copy of the GNU General Public License
-#   along with this program;  if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+#   along with this program;  if not, see
+#   <http://www.gnu.org/licenses/>.
 #
 #
 # geninfo

--- a/bin/genpng
+++ b/bin/genpng
@@ -13,8 +13,8 @@
 #   General Public License for more details.                 
 #
 #   You should have received a copy of the GNU General Public License
-#   along with this program;  if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+#   along with this program;  if not, see
+#   <http://www.gnu.org/licenses/>.
 #
 #
 # genpng

--- a/bin/lcov
+++ b/bin/lcov
@@ -13,8 +13,8 @@
 #   General Public License for more details.                 
 #
 #   You should have received a copy of the GNU General Public License
-#   along with this program;  if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+#   along with this program;  if not, see
+#   <http://www.gnu.org/licenses/>.
 #
 #
 # lcov


### PR DESCRIPTION
The FSF address used in the license boilerplate text is no longer
correct since their offices have relocated. Rather than introduce
the new mailing address which will inevitably change again in the
future, use the website address which is more permanent.

The main COPYING file already had the correct mailing address and
is not desirable to change that to the URL since it is a legal
document.

Signed-off-by: Daniel P. Berrangé <berrange@redhat.com>