### PR TITLE
Allow to override man page date

### DIFF
--- a/bin/updateversion.pl
+++ b/bin/updateversion.pl
@@ -84,7 +84,9 @@ sub get_file_info($)
 
 	return (0, 0, 0) if (!-e $filename);
 	@stat = stat($filename);
-	($sec, $min, $hour, $day, $month, $year) = gmtime($stat[9]);
+	my $epoch = int($ENV{SOURCE_DATE_EPOCH});
+	$epoch = $stat[9] if not $epoch or $stat[9] < $epoch;
+	($sec, $min, $hour, $day, $month, $year) = gmtime($epoch);
 	$year += 1900;
 	$month += 1;
 


### PR DESCRIPTION
Allow to override man page date

Without this patch, man page mtime would be updated by a `sed` call
in `install.sh` and then written here as text into the output:

```diff
+++ /usr/share/man/man5/lcovrc.5
-.TH lcovrc 5 "uq2000-02-02" 2019\-06\-22 "User Manuals"
+.TH lcovrc 5 "uq2000-02-02" 2034\-07\-24 "User Manuals"
```

For files older than `SOURCE_DATE_EPOCH`, the mtime is still used
to give more meaningful results.

See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.