### PR TITLE
Enabled collection of branch coverage data but excluding exception branches.

### DIFF
--- a/bin/geninfo
+++ b/bin/geninfo
@@ -96,9 +96,13 @@ our %ERROR_ID = (
 our $EXCL_START = "LCOV_EXCL_START";
 our $EXCL_STOP = "LCOV_EXCL_STOP";
 
-# Marker to exclude branch coverage but keep function and line coveage
+# Marker to exclude branch coverage but keep function and line coverage
 our $EXCL_BR_START = "LCOV_EXCL_BR_START";
 our $EXCL_BR_STOP = "LCOV_EXCL_BR_STOP";
+
+# Marker to exclude exception branch coverage but keep function, line coverage and non-exception branch coverage
+our $EXCL_EXCEPTION_BR_START = "LCOV_EXCL_EXCEPTION_BR_START";
+our $EXCL_EXCEPTION_BR_STOP = "LCOV_EXCL_EXCEPTION_BR_STOP";
 
 # Compatibility mode values
 our $COMPAT_VALUE_OFF	= 0;
@@ -268,11 +272,13 @@ our %compat_value;
 our $gcno_split_crc;
 our $func_coverage = 1;
 our $br_coverage = 0;
+our $no_exception_br = 0;
 our $rc_auto_base = 1;
 our $rc_intermediate = "auto";
 our $intermediate;
 our $excl_line = "LCOV_EXCL_LINE";
 our $excl_br_line = "LCOV_EXCL_BR_LINE";
+our $excl_exception_br_line = "LCOV_EXCL_EXCEPTION_BR_LINE";
 
 our $cwd = `pwd`;
 chomp($cwd);
@@ -339,10 +345,12 @@ if ($config || %opt_rc)
 		"geninfo_adjust_src_path"	=> \$rc_adjust_src_path,
 		"geninfo_auto_base"		=> \$rc_auto_base,
 		"geninfo_intermediate"		=> \$rc_intermediate,
+		"geninfo_no_exception_branch"	=> \$no_exception_br,
 		"lcov_function_coverage"	=> \$func_coverage,
 		"lcov_branch_coverage"		=> \$br_coverage,
 		"lcov_excl_line"		=> \$excl_line,
 		"lcov_excl_br_line"		=> \$excl_br_line,
+		"lcov_excl_exception_br_line"		=> \$excl_exception_br_line,
 	});
 
 	# Merge options
@@ -372,7 +380,7 @@ if ($config || %opt_rc)
 			$adjust_src_replace = $replace;
 		}
 	}
-	for my $regexp (($excl_line, $excl_br_line)) {
+	for my $regexp (($excl_line, $excl_br_line, $excl_exception_br_line)) {
 		eval 'qr/'.$regexp.'/';
 		my $error = $@;
 		chomp($error);
@@ -476,8 +484,9 @@ if ($rc_intermediate eq "0") {
 } elsif ($rc_intermediate eq "1") {
 	$intermediate = 1;
 } elsif (lc($rc_intermediate) eq "auto") {
-	# Use intermediate format if supported by gcov
-	$intermediate = ($gcov_caps->{'intermediate-format'} ||
+	# Use intermediate format if supported by gcov and not conflicting with
+	# exception branch exclusion
+	$intermediate = (($gcov_caps->{'intermediate-format'} && !$no_exception_br) ||
 			 $gcov_caps->{'json-format'}) ? 1 : 0;
 } else {
 	die("ERROR: invalid value for geninfo_intermediate: ".
@@ -491,6 +500,15 @@ if ($intermediate) {
 		     "intermediate format - ignoring\n");
 		$opt_derive_func_data = 0;
 	}
+	if ($no_exception_br && !$gcov_caps->{'json-format'}) {
+		die("ERROR: excluding exception branches is not compatible with ".
+		    "text intermediate format\n");
+	}
+}
+
+if ($no_exception_br && ($gcov_version < $GCOV_VERSION_3_3_0)) {
+	die("ERROR: excluding exception branches is not compatible with ".
+	    "gcov versions older than 3.3\n");
 }
 
 # Determine gcov options
@@ -1843,7 +1861,9 @@ sub read_gcov_file($)
 	my $exclude_flag = 0;
 	my $exclude_line = 0;
 	my $exclude_br_flag = 0;
+	my $exclude_exception_br_flag = 0;
 	my $exclude_branch = 0;
+	my $exclude_exception_branch = 0;
 	my $last_block = $UNNAMED_BLOCK;
 	my $last_line = 0;
 	local *INPUT;
@@ -1913,6 +1933,13 @@ sub read_gcov_file($)
 						$exclude_branch = 0;
 					}
 				}
+				# Check for exclusion markers (exception branch exclude)
+				if (!$no_markers && 
+					/($EXCL_EXCEPTION_BR_STOP|$EXCL_EXCEPTION_BR_START|$excl_exception_br_line)/) {
+					warn("WARNING: $1 found at $filename:$last_line but ".
+					"branch exceptions exclusion is not supported with ".
+					"gcov versions older than 3.3\n");
+				}
 				# Source code execution data
 				if (/^\t\t(.*)$/)
 				{
@@ -1955,10 +1982,12 @@ sub read_gcov_file($)
 				# branches
 				$last_line = $2;
 				$last_block = $3;
-			} elsif (/^branch\s+(\d+)\s+taken\s+(\d+)/) {
+			} elsif (/^branch\s+(\d+)\s+taken\s+(\d+)(?:\s+\(([^)]*)\))?/) {
 				next if (!$br_coverage);
 				next if ($exclude_line);
 				next if ($exclude_branch);
+				next if (($exclude_exception_branch || $no_exception_br) && 
+						 defined($3) && ($3 eq "throw"));
 				$branches = br_gvec_push($branches, $last_line,
 						$last_block, $1, $2);
 			} elsif (/^branch\s+(\d+)\s+never\s+executed/) {
@@ -2015,6 +2044,19 @@ sub read_gcov_file($)
 						$exclude_branch = 0;
 					}
 				}
+				# Check for exclusion markers (exception branch exclude)
+				if (!$no_markers) {
+					if (/$EXCL_EXCEPTION_BR_STOP/) {
+						$exclude_exception_br_flag = 0;
+					} elsif (/$EXCL_EXCEPTION_BR_START/) {
+						$exclude_exception_br_flag = 1;
+					}
+					if (/$excl_exception_br_line/ || $exclude_exception_br_flag) {
+						$exclude_exception_branch = 1;
+					} else {
+						$exclude_exception_branch = 0;
+					}
+				}
 
 				# Strip unexecuted basic block marker
 				$count =~ s/\*$//;
@@ -2051,7 +2093,7 @@ sub read_gcov_file($)
 	}
 
 	close(INPUT);
-	if ($exclude_flag || $exclude_br_flag) {
+	if ($exclude_flag || $exclude_br_flag || $exclude_exception_br_flag) {
 		warn("WARNING: unterminated exclusion section in $filename\n");
 	}
 	return(\@result, $branches, \@functions);
@@ -2141,6 +2183,7 @@ sub read_intermediate_json($$$)
 # srcdata:   filename -> [ excl, brexcl, checksums ]
 # excl:      lineno -> 1 for all lines for which to exclude all data
 # brexcl:    lineno -> 1 for all lines for which to exclude branch data
+#                      2 for all lines for which to exclude exception branch data
 # checksums: lineno -> source code checksum
 #
 # Note: To simplify processing, gcov data is not combined here, that is counts
@@ -2200,7 +2243,7 @@ sub intermediate_text_to_info($$$)
 				print($fd "FNDA:$2,$3\n");
 			} elsif ($line =~ /^branch:(\d+),(taken|nottaken|notexec)/) {
 				next if (!$br_coverage || $excl->{$1} ||
-					 $brexcl->{$1});
+					 (defined($brexcl->{$1}) && ($brexcl->{$1} == 1)));
 
 				# branch:<line>,taken|nottaken|notexec
 				if ($2 eq "taken") {
@@ -2230,6 +2273,7 @@ sub intermediate_text_to_info($$$)
 # srcdata:   filename -> [ excl, brexcl, checksums ]
 # excl:      lineno -> 1 for all lines for which to exclude all data
 # brexcl:    lineno -> 1 for all lines for which to exclude branch data
+#                      2 for all lines for which to exclude exception branch data
 # checksums: lineno -> source code checksum
 #
 # Note: To simplify processing, gcov data is not combined here, that is counts
@@ -2296,15 +2340,20 @@ sub intermediate_json_to_info($$$)
 
 			$branch_num = 0;
 			# Branch data
-			if ($br_coverage && !$brexcl->{$line}) {
+			if ($br_coverage && (!defined($brexcl->{$line}) || 
+					($brexcl->{$line} != 1))) {
 				for my $b (@$branches) {
 					my $brcount = $b->{"count"};
+					my $is_exception = $b->{"throw"};
 
-					if (!defined($brcount) || $unexec) {
-						$brcount = "-";
+					if (!$is_exception || ((!defined($brexcl->{$line}) || 
+							($brexcl->{$line} != 2)) && !$no_exception_br)) {
+						if (!defined($brcount) || $unexec) {
+							$brcount = "-";
+						}
+						print($fd "BRDA:$line,0,$branch_num,".
+						      "$brcount\n");
 					}
-					print($fd "BRDA:$line,0,$branch_num,".
-					      "$brcount\n");
 
 					$branch_num++;
 				}
@@ -2795,6 +2844,7 @@ sub get_source_data($)
 	my $flag = 0;
 	my %brdata;
 	my $brflag = 0;
+	my $exceptionbrflag = 0;
 	my %checksums;
 	local *HANDLE;
 
@@ -2816,12 +2866,25 @@ sub get_source_data($)
 		} elsif (/$EXCL_BR_START/) {
 			$brflag = 1;
 		}
+		if (/$EXCL_EXCEPTION_BR_STOP/) {
+			$exceptionbrflag = 0;
+		} elsif (/$EXCL_EXCEPTION_BR_START/) {
+			$exceptionbrflag = 1;
+		}
 		if (/$excl_br_line/ || $brflag) {
 			$brdata{$.} = 1;
+		} elsif (/$excl_exception_br_line/ || $exceptionbrflag) {
+			$brdata{$.} = 2;
 		}
 		if ($checksum) {
 			chomp();
 			$checksums{$.} = md5_base64($_);
+		}
+		if ($intermediate && !$gcov_caps->{'json-format'} &&
+				/($EXCL_EXCEPTION_BR_STOP|$EXCL_EXCEPTION_BR_START|$excl_exception_br_line)/) {
+			warn("WARNING: $1 found at $filename:$. but branch exceptions ".
+				"exclusion is not supported when using text intermediate ".
+				"format\n");
 		}
 	}
 	close(HANDLE);

--- a/lcovrc
+++ b/lcovrc
@@ -137,6 +137,9 @@ geninfo_auto_base = 1
 # Use gcov intermediate format? Valid values are 0, 1, auto
 geninfo_intermediate = auto
 
+# Specify if exception branches should be excluded from branch coverage.
+geninfo_no_exception_branch = 0
+
 # Directory containing gcov kernel files
 # lcov_gcov_dir = /proc/gcov
 

--- a/man/geninfo.1
+++ b/man/geninfo.1
@@ -123,6 +123,25 @@ Marks the end of a section which is excluded from branch coverage. The current
 line not part of this section.
 .RE
 .br
+LCOV_EXCL_EXCEPTION_BR_LINE
+.RS
+Lines containing this marker will be excluded from exception branch coverage:
+Exception branches will be ignored, but non-exception branches will not be
+affected.
+.br
+.RE
+LCOV_EXCL_EXCEPTION_BR_START
+.RS
+Marks the beginning of a section which is excluded from exception branch 
+coverage. The current line is part of this section.
+.br
+.RE
+LCOV_EXCL_EXCEPTION_BR_STOP
+.RS
+Marks the end of a section which is excluded from exception branch coverage. 
+The current line not part of this section.
+.RE
+.br
 
 .SH OPTIONS
 

--- a/man/lcovrc.5
+++ b/man/lcovrc.5
@@ -813,6 +813,15 @@ use immediate format when supported by gcov.
 Default is "auto".
 .PP
 
+.BR geninfo_no_exception_branch " ="
+.IR 0 | 1
+.IP
+Specify whether to exclude exception branches from branch coverage.
+.br
+
+Default is 0.
+.PP
+
 .BR lcov_gcov_dir " ="
 .I path_to_kernel_coverage_data
 .IP
@@ -915,6 +924,15 @@ Specify the regular expression of lines to exclude from branch coverage.
 .br
 
 Default is 'LCOV_EXCL_BR_LINE'.
+.PP
+
+.BR lcov_excl_exception_br_line " ="
+.I expression
+.IP
+Specify the regular expression of lines to exclude from exception branch coverage.
+.br
+
+Default is 'LCOV_EXCL_EXCEPTION_BR_LINE'.
 .PP
 
 .SH FILES


### PR DESCRIPTION
Branch coverage of C++ files is too often too low because exceptions happen in generated code all over the place: when an object is created dynamically, when a function or method is called, etc.

For many projects the testing strategy consists in testing all explicit branches (branches that actually are present in source code), and testing implicit exception branches is out of scope, just because testing most exception branches is very complicated as most of them are related to out-of-memory exceptions and that would require an enormous effort that doesn't compensate the benefits.

If we don't care about exception branches, exploring coverage reports full of not interesting errors is tedious and the probabilities of overlooking a "real" lack of branch coverage are high. Having to manually exclude from branch coverage hundreds of lines of code is not only exhausting and problematic when maintaining the source code, but also leaves a pretty ugly source code.

To overcome this problem this contribution has implemented the following changes:

- Added extra option "exclude-coverage" to lcov_branch_coverage that makes geninfo always ignore exception branches when collecting branch coverage data.

- Added new markers LCOV_EXCL_EXCEPTION_BR_LINE, LCOV_EXCL_EXCEPTION_BR_START and LCOV_EXCL_EXCEPTION_BR_STOP to selectively disable in the source code the collection of exception branch data (to be used with lcov_branch_coverage=1).

- Modified geninfo_intermediate=auto behavior to default to no intermediate file processing if lcov_branch_coverage is set to "exclude-coverage" and the intermediate file has text type, because the text intermediate format does not have the necessary branch info.