### PR TITLE
geninfo: Change json module

### DIFF
--- a/bin/geninfo
+++ b/bin/geninfo
@@ -60,7 +60,7 @@ use Getopt::Long;
 use Digest::MD5 qw(md5_base64);
 use Cwd qw/abs_path/;
 use IO::Uncompress::Gunzip qw(gunzip $GunzipError);
-use JSON qw(decode_json);
+use JSON:PP qw(decode_json);
 
 if( $^O eq "msys" )
 {


### PR DESCRIPTION
Perl module JSON may not be present on all distributions. Switch to
using JSON:PP instead which is a Perl core module since Perl 5.14.0.

xref: https://perldoc.perl.org/5.14.0/index-modules-J.html

Note: JSON:PP is included in packages named perl-JSON-PP or
libjson-pp-perl on some distributions

Signed-off-by: Nehal J Wani <nehaljw.kkd1@gmail.com>