### PR TITLE
support case insensitive property of extract/remove file pattern on windows

### DIFF
--- a/bin/lcov
+++ b/bin/lcov
@@ -112,6 +112,7 @@ sub merge_checksums($$$);
 sub combine_info_entries($$$);
 sub combine_info_files($$);
 sub write_info_file(*$);
+sub check_file_pattern($$);
 sub extract();
 sub remove();
 sub list();
@@ -2714,6 +2715,27 @@ sub transform_pattern($)
 	return $pattern;
 }
 
+#
+# check_file_pattern(filename, pattern)
+# compare filename with input pattern
+#
+
+sub check_file_pattern($$)
+{
+	my $filename = $_[0];
+	my $pattern = $_[1];
+	my $os = $^O;
+
+	# path of win32 is case insensitive
+	if ($os eq "MSWin32" || $os eq "msys")
+	{
+		return ($filename =~ (/^$pattern$/i));
+	}
+	else
+	{
+		return ($filename =~ (/^$pattern$/));
+	}
+}
 
 #
 # extract()
@@ -2740,7 +2762,7 @@ sub extract()
 
 		foreach $pattern (@pattern_list)
 		{
-			$keep ||= ($filename =~ (/^$pattern$/));
+			$keep ||= check_file_pattern($filename, $pattern);
 		}
 
 
@@ -2799,7 +2821,7 @@ sub remove()
 
 		foreach $pattern (@pattern_list)
 		{
-			$match_found ||= ($filename =~ (/^$pattern$/));
+			$match_found ||= check_file_pattern($filename, $pattern);
 		}
 
 


### PR DESCRIPTION
i want to use bash script to remove stdlib header coverage info, but it fails!
because there is a property of case insensitive on windows platform.
eg:
if Path is D:\test,
```bash
# these cases are valid on windows mingw bash
cd /d/test
#pwd value is: /d/test
cd /d/TEST
#pwd value is: /d/TEST
cd /D/test
#pwd value is: /D/test
```
character case in lcov cache may be correct, but the return value of $(pwd) command may be case-mixed.
on windows platform, i think its better to compare file pattern without considering character case.

Signed-off-by: FangGe fang.g@bigforce.cn