### PR TITLE
support remove CR endings of old intermediate text

### DIFF
--- a/bin/geninfo
+++ b/bin/geninfo
@@ -2079,7 +2079,7 @@ sub read_intermediate_text($$)
 	while (my $line = <$fd>) {
 		if ($line =~ /^file:(.*)$/) {
 			$filename = $1;
-			chomp($filename);
+			$filename =~ s/[\r\n]$//g;
 		} elsif (defined($filename)) {
 			$data->{$filename} .= $line;
 		}


### PR DESCRIPTION
at 1.15 version someone who reconstructed the parsing logic of old intermediate text file, forget to remove CR endings of line. On mingw gcc toolkits, gcov outputs with CRLF, if CRs are not removed, filenames with CR control charaters cannot be used to read file correctlly 

Signed-off-by: FangGe fang.g@bigforce.cn