### PR TITLE
lcov: quote tool_dir to enable paths with spaces.

### DIFF
--- a/bin/gendesc
+++ b/bin/gendesc
@@ -44,7 +44,7 @@ use Cwd qw/abs_path/;
 
 # Constants
 our $tool_dir		= abs_path(dirname($0));
-our $lcov_version	= 'LCOV version '.`$tool_dir/get_version.sh --full`;
+our $lcov_version	= 'LCOV version '.`"$tool_dir"/get_version.sh --full`;
 our $lcov_url		= "http://ltp.sourceforge.net/coverage/lcov.php";
 our $tool_name		= basename($0);
 

--- a/bin/genhtml
+++ b/bin/genhtml
@@ -76,7 +76,7 @@ use Cwd qw/abs_path cwd/;
 # Global constants
 our $title		= "LCOV - code coverage report";
 our $tool_dir		= abs_path(dirname($0));
-our $lcov_version	= 'LCOV version '.`$tool_dir/get_version.sh --full`;
+our $lcov_version	= 'LCOV version '.`"$tool_dir"/get_version.sh --full`;
 our $lcov_url		= "http://ltp.sourceforge.net/coverage/lcov.php";
 our $tool_name		= basename($0);
 

--- a/bin/geninfo
+++ b/bin/geninfo
@@ -69,7 +69,7 @@ if( $^O eq "msys" )
 
 # Constants
 our $tool_dir		= abs_path(dirname($0));
-our $lcov_version	= 'LCOV version '.`$tool_dir/get_version.sh --full`;
+our $lcov_version	= 'LCOV version '.`"$tool_dir"/get_version.sh --full`;
 our $lcov_url		= "http://ltp.sourceforge.net/coverage/lcov.php";
 our $gcov_tool		= "gcov";
 our $tool_name		= basename($0);
@@ -2666,7 +2666,7 @@ sub get_gcov_version()
 	#       Default target: x86_64-apple-darwin16.0.0
 	#       Host CPU: haswell
 
-	open(GCOV_PIPE, "-|", "$gcov_tool --version")
+	open(GCOV_PIPE, "-|", "\"$gcov_tool\" --version")
 		or die("ERROR: cannot retrieve gcov version!\n");
 	local $/;
 	$version_string = <GCOV_PIPE>;
@@ -4472,7 +4472,7 @@ sub debug($)
 
 sub get_gcov_capabilities()
 {
-	my $help = `$gcov_tool --help`;
+	my $help = `"$gcov_tool" --help`;
 	my %capabilities;
 	my %short_option_translations = (
 		'a' => 'all-blocks',

--- a/bin/genpng
+++ b/bin/genpng
@@ -38,7 +38,7 @@ use Cwd qw/abs_path/;
 
 # Constants
 our $tool_dir		= abs_path(dirname($0));
-our $lcov_version	= 'LCOV version '.`$tool_dir/get_version.sh --full`;
+our $lcov_version	= 'LCOV version '.`"$tool_dir"/get_version.sh --full`;
 our $lcov_url		= "http://ltp.sourceforge.net/coverage/lcov.php";
 our $tool_name		= basename($0);
 

--- a/bin/get_version.sh
+++ b/bin/get_version.sh
@@ -4,9 +4,9 @@
 #
 # Print lcov version or release information as provided by Git, .version
 # or a fallback.
-
-TOOLDIR=$(cd $(dirname $0) >/dev/null ; pwd)
-GITVER=$(cd $TOOLDIR ; git describe --tags 2>/dev/null)
+DIRPATH=$(dirname "$0")
+TOOLDIR=$(cd "$DIRPATH" >/dev/null ; pwd)
+GITVER=$(cd "$TOOLDIR" ; git describe --tags 2>/dev/null)
 
 if [ -z "$GITVER" ] ; then
 	# Get version information from file

--- a/bin/lcov
+++ b/bin/lcov
@@ -73,7 +73,7 @@ use Cwd qw /abs_path getcwd/;
 
 # Global constants
 our $tool_dir		= abs_path(dirname($0));
-our $lcov_version	= 'LCOV version '.`$tool_dir/get_version.sh --full`;
+our $lcov_version	= 'LCOV version '.`"$tool_dir"/get_version.sh --full`;
 our $lcov_url		= "http://ltp.sourceforge.net/coverage/lcov.php";
 our $tool_name		= basename($0);
 


### PR DESCRIPTION
When a copy of lcov is located in a path with spaces or ('s, things break. This fixes things on my side.