### PR TITLE
Excluding exception branches

### DIFF
--- a/bin/geninfo
+++ b/bin/geninfo
@@ -2390,6 +2390,13 @@ sub intermediate_json_to_info($$$)
 			# Branch data
 			if ($br_coverage && (!defined($brexcl->{$line}) || 
 					($brexcl->{$line} != 1))) {
+				my $branch_index = 0;
+				for my $b (@$branches) {
+					if($b->{"throw"}) {
+						@$branches[$branch_index-1]->{"throw"} = 1;
+					}
+					$branch_index++;
+				}
 				for my $b (@$branches) {
 					my $brcount = $b->{"count"};
 					my $is_exception = $b->{"throw"};


### PR DESCRIPTION
Hi,
The new lcov `exclude coverage` option will only remove one exceptional branch, but each exception will always create 2 or more branches, so I've updated the code to remove the previous branch as well. 

I have tried your solution from Pull Request #80 on this simple project: https://github.com/ghandmann/lcov-branch-coverage-weirdness

**Result before using your solution:**
![87422252-99abc380-c5d8-11ea-8003-e2b05c724447](https://user-images.githubusercontent.com/47740276/93770786-f81aa100-fc1c-11ea-9185-6df4a4576f11.png)

**Result after using your solution - removing one exeptional branch:**
![87422305-af20ed80-c5d8-11ea-8ce6-5ac528ec3d49](https://user-images.githubusercontent.com/47740276/93770808-fea91880-fc1c-11ea-8413-8e6bf773bc07.png)

**Result after using my edited solution - removing one exceptional branch and also the previous branch:**
![image](https://user-images.githubusercontent.com/47740276/93770991-3b750f80-fc1d-11ea-8c08-f5aa15e8012e.png)

But I think using `-fno-exception` is still a better choice, because each exception can create **more than 2** branches and this solution will only delete 2.
Issue #75 