### PR TITLE
Add possibility to configure json module

### DIFF
--- a/bin/geninfo
+++ b/bin/geninfo
@@ -60,7 +60,6 @@ use Getopt::Long;
 use Digest::MD5 qw(md5_base64);
 use Cwd qw/abs_path/;
 use IO::Uncompress::Gunzip qw(gunzip $GunzipError);
-use JSON::PP qw(decode_json);
 
 if( $^O eq "msys" )
 {
@@ -275,6 +274,7 @@ our $br_coverage = 0;
 our $no_exception_br = 0;
 our $rc_auto_base = 1;
 our $rc_intermediate = "auto";
+our $rc_json_module = "auto";
 our $intermediate;
 our $excl_line = "LCOV_EXCL_LINE";
 our $excl_br_line = "LCOV_EXCL_BR_LINE";
@@ -345,6 +345,7 @@ if ($config || %opt_rc)
 		"geninfo_adjust_src_path"	=> \$rc_adjust_src_path,
 		"geninfo_auto_base"		=> \$rc_auto_base,
 		"geninfo_intermediate"		=> \$rc_intermediate,
+		"geninfo_json_module"		=> \$rc_json_module,
 		"geninfo_no_exception_branch"	=> \$no_exception_br,
 		"lcov_function_coverage"	=> \$func_coverage,
 		"lcov_branch_coverage"		=> \$br_coverage,
@@ -492,6 +493,18 @@ if ($rc_intermediate eq "0") {
 	die("ERROR: invalid value for geninfo_intermediate: ".
 	    "'$rc_intermediate'\n");
 }
+
+# Determine JSON module
+my $current_json_module = "JSON::PP";
+if ($rc_json_module ne "auto") {
+	$current_json_module = $rc_json_module
+}
+
+use Module::Load;
+eval "load $current_json_module, 'decode_json'";
+if ($@) {
+	die("Module is not installed: ". "'$current_json_module'\n");
+};
 
 if ($intermediate) {
 	info("Using intermediate gcov format\n");


### PR DESCRIPTION
By moving from gcov-5 to gcov-9 i faced performance problem.
My investigations shows that LCov-1.15 uses core module JSON::PP for parsing gcov-9 output. This slowed down analysis for my project 10 times (with gcov5 they uses txt format)

My changes add possibility to configure json module for LCov
Now to reach past performance i can force LСov to use fast JSON::XS module, e.q.:

`> lcov  --capture --directory $products --output-file $file -rc geninfo_json_module=JSON::XS `

As this is not core module you should to install it by yourself:

`> cpan JSON:XS`