### PR TITLE
lcov: add a new --fail-under-lines option

### DIFF
--- a/bin/lcov
+++ b/bin/lcov
@@ -131,6 +131,7 @@ sub temp_cleanup();
 sub setup_gkv();
 sub get_overall_line($$$$);
 sub print_overall_rate($$$$$$$$$);
+sub check_rates($$);
 sub lcov_geninfo(@);
 sub create_package($$$;$);
 sub get_func_found_and_hit($);
@@ -159,6 +160,7 @@ our $cwd = `pwd`;	# Current working directory
 our $data_stdout;	# If set, indicates that data is written to stdout
 our $follow;		# If set, indicates that find shall follow links
 our $diff_path = "";	# Path removed from tracefile when applying diff
+our $opt_fail_under_lines = 0;
 our $base_directory;	# Base directory (cwd of gcc during compilation)
 our $checksum;		# If set, calculate a checksum for each line
 our $no_checksum;	# If set, don't calculate a checksum for each line
@@ -300,6 +302,7 @@ if (!GetOptions("directory|d|di=s" => \@directory,
 		"compat=s" => \$opt_compat,
 		"config-file=s" => \$opt_config_file,
 		"rc=s%" => \%opt_rc,
+		"fail-under-lines=s" => \$opt_fail_under_lines,
 		))
 {
 	print(STDERR "Use $tool_name --help to get usage information\n");
@@ -400,6 +403,7 @@ if (!$from_package && !@directory && ($capture || $reset)) {
 	($gcov_gkv, $gcov_dir) = setup_gkv();
 }
 
+our $exit_code = 0;
 # Check for requested functionality
 if ($reset)
 {
@@ -473,6 +477,7 @@ elsif (@opt_summary)
 	($ln_overall_found, $ln_overall_hit,
 	 $fn_overall_found, $fn_overall_hit,
 	 $br_overall_found, $br_overall_hit) = summary();
+	$exit_code = check_rates($ln_overall_found, $ln_overall_hit);
 }
 
 temp_cleanup();
@@ -484,7 +489,7 @@ if (defined($ln_overall_found)) {
 } else {
 	info("Done.\n") if (!$list && !$capture);
 }
-exit(0);
+exit($exit_code);
 
 #
 # print_usage(handle)
@@ -545,6 +550,8 @@ Options:
       --compat MODE=on|off|auto   Set compat MODE (libtool, hammer, split_crc)
       --include PATTERN           Include files matching PATTERN
       --exclude PATTERN           Exclude files matching PATTERN
+      --fail-under-lines MIN      Exit with a status of 1 if the total line
+                                  coverage is less than MIN (summary option).
 
 For more information see: $lcov_url
 END_OF_USAGE
@@ -4291,6 +4298,33 @@ sub print_overall_rate($$$$$$$$$)
 	info("  branches...: %s\n",
 	     get_overall_line($br_found, $br_hit, "branch", "branches"))
 		if ($br_do);
+}
+
+#
+# check_rates(ln_found, ln_hit)
+#
+# Check line coverage if it meets a specified threshold.
+#
+
+sub check_rates($$)
+{
+	my ($ln_found, $ln_hit) = @_;
+
+	if ($opt_fail_under_lines <= 0) {
+		return 0;
+	}
+
+	if ($ln_found == 0) {
+		return 1;
+	}
+
+	my $actual_rate = ($ln_hit / $ln_found);
+	my $expected_rate = $opt_fail_under_lines / 100;
+	if ($actual_rate >= $expected_rate) {
+		return 0;
+	} else {
+		return 1;
+	}
 }
 
 

--- a/man/lcov.1
+++ b/man/lcov.1
@@ -170,6 +170,8 @@ lcov \- a graphical GCOV front\-end
 .RS 5
 .br
 .RB [ \-q | \-\-quiet ]
+.RB [ \-\-fail-under-lines
+.IR percentage ]
 .br
 .RE
 
@@ -842,6 +844,14 @@ Note that you may specify this option more than once.
 
 Only one of  \-z, \-c, \-a, \-e, \-r, \-l, \-\-diff or \-\-summary may be
 specified at a time.
+.RE
+
+.B \-\-fail-under-lines
+.I percentage
+.br
+.RS
+Use this option together with \-\-summary to tell lcov to exit with a status of 1 if the total
+line coverage is less than percentage.
 .RE
 
 .B \-t


### PR DESCRIPTION
This allows requiring a certain line coverage during CI.

This is modeled after python's "coverage report --fail-under=100" or
nodejs' "nyc report --statements 100", but it's for line coverage.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>