### PR TITLE
genhtml: stop using obsolete <a name="">

### DIFF
--- a/bin/genhtml
+++ b/bin/genhtml
@@ -4348,7 +4348,7 @@ sub write_source_line(*$$$$$)
 
 	# Write out a line number navigation anchor every $nav_resolution
 	# lines if necessary
-	$anchor_start	= "<a name=\"$_[1]\">";
+	$anchor_start	= "<a id=\"$_[1]\">";
 	$anchor_end	= "</a>";
 
 


### PR DESCRIPTION
Since HTML5 using a name attribute on an anchor is obsolete, switch to
an id which is the modern alternative.

Signed-off-by: Jelle van der Waa <jvanderwaa@redhat.com>