### PR TITLE
Handle negative hit count:  report as ignorable error, set to zero.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,12 +40,6 @@ LIBS = lcovutil
 MANPAGES = man1/lcov.1 man1/genhtml.1 man1/geninfo.1 man1/genpng.1 \
 	man1/gendesc.1 man5/lcovrc.5
 
-# Files to be checked for coding style issue issues -
-#   - anything containing "#!/usr/bin/env perl" or the like
-#   - anything named *.pm - expected to be perl module
-CHECKFILES := $(shell grep -lr '^\#!.*perl' --exclude-dir .git --exclude '*.tdy' ) $(shell find . -name '*.pm' )
-
-
 # Program for checking coding style
 CHECKSTYLE = $(CURDIR)/bin/checkstyle.sh
 
@@ -147,15 +141,19 @@ test: check
 check:
 	@$(MAKE) -s -C tests check
 
+# Files to be checked for coding style issue issues -
+#   - anything containing "#!/usr/bin/env perl" or the like
+#   - anything named *.pm - expected to be perl module
+# ... as long as the name doesn't end in .tdy or .orig
 checkstyle:
 ifeq ($(MODE),full)
 	@echo "Checking source files for coding style issues (MODE=full):"
 else
 	@echo "Checking changes in source files for coding style issues (MODE=diff):"
 endif
-	#echo "checking $(CHECKFILES)"
 	@RC=0 ;                                                  \
-	for FILE in $(CHECKFILES) ; do                           \
+	CHECKFILES=`find . \( \( -type f -exec grep -q '^\#!.*perl' {} \; \) -o -name '*.pm' \) -not \( -name '*.tdy' -o -name '*.orig' \) -print `; \
+	for FILE in $$CHECKFILES ; do                            \
 	  $(CHECKSTYLE) "$$FILE";                                \
 	  if [ 0 != $$? ] ; then                                 \
 	    RC=1;                                                \

--- a/bin/genhtml
+++ b/bin/genhtml
@@ -102,7 +102,7 @@ use lcovutil qw (set_tool_name define_errors parse_ignore_errors
                  ignorable_error
                  $ERROR_MISMATCH $ERROR_SOURCE $ERROR_BRANCH $ERROR_FORMAT
                  $ERROR_EMPTY $ERROR_VERSION $ERROR_UNUSED $ERROR_PACKAGE
-                 $ERROR_CORRUPT
+                 $ERROR_CORRUPT $ERROR_NEGATIVE $ERROR_COUNT
                  $ERROR_PARALLEL report_parallel_error
                  info $verbose init_verbose_flag
                  do_mangle_check
@@ -206,6 +206,8 @@ our $ERROR_ANNOTATE_SCRIPT = 11;
 $ERROR_PARALLEL = 12;
 $ERROR_PACKAGE  = 13;
 $ERROR_CORRUPT  = 14;
+$ERROR_NEGATIVE = 15;
+$ERROR_COUNT    = 16;
 
 our %htmlErrs = ("source"       => $ERROR_SOURCE,
                  "unmapped"     => $ERROR_UNMAPPED_LINE,
@@ -221,6 +223,8 @@ our %htmlErrs = ("source"       => $ERROR_SOURCE,
                  "unused"       => $ERROR_UNUSED,
                  "parallel"     => $ERROR_PARALLEL,
                  "package"      => $ERROR_PACKAGE,
+                 "negative"     => $ERROR_NEGATIVE,
+                 "count"        => $ERROR_COUNT,
                  "corrupt"      => $ERROR_CORRUPT,);
 lcovutil::define_errors(\%htmlErrs);
 
@@ -4708,6 +4712,7 @@ lcovutil::apply_rc_params(\@opt_config_file,
                            "lcov_function_coverage" => \$lcov_func_coverage,
                            "lcov_branch_coverage"   => \$lcov_branch_coverage,
                            "ignore_errors"          => \@rc_ignore,
+                           "max_message_count"   => \$lcovutil::suppressAfter,
                            'stop_on_error'       => \$lcovutil::stop_on_error,
                            "rtl_file_extensions" => \$rtlExtensions,
                            "c_file_extensions"   => \$cExtensions,

--- a/bin/geninfo
+++ b/bin/geninfo
@@ -308,6 +308,7 @@ if (lcovutil::apply_rc_params(
                    "lcov_excl_br_line"      => \$excl_br_line,
                    "lcov_excl_exception_br_line" => \$excl_exception_br_line,
                    'ignore_errors'               => \@rc_ignore,
+                   "max_message_count"           => \$lcovutil::suppressAfter,
                    'stop_on_error'               => \$lcovutil::stop_on_error,
                    "profile"                     => \$lcovutil::profile,
                    "parallel"                    => \$lcovutil::maxParallelism,
@@ -2008,6 +2009,12 @@ sub read_gcov_file($$$)
                 } else {
                     # Check for zero count
                     if ($count =~ /^[#=]/) {
+                        $count = 0;
+                    } elsif ($count < 0) {
+                        #negative...
+                        lcovutil::ignorable_error($lcovutil::ERROR_NEGATIVE,
+                            "Unexpected negative count '$count' for $source_filename:$line at $filename:$.\n\tPerhaps you need to compile with '-fprofile-update=atomic"
+                        );
                         $count = 0;
                     }
                     push(@result, 1, $count);

--- a/bin/lcov
+++ b/bin/lcov
@@ -251,6 +251,7 @@ lcovutil::apply_rc_params(
                "filter_bitwise_conditional" =>
                    \$lcovutil::source_filter_bitwise_are_conditional,
                'ignore_errors'               => \@rc_ignore,
+               "max_message_count"           => \$lcovutil::suppressAfter,
                'stop_on_error'               => \$lcovutil::stop_on_error,
                "profile"                     => \$lcovutil::profile,
                "parallel"                    => \$lcovutil::maxParallelism,
@@ -808,7 +809,7 @@ sub lcov_copy_single($$)
 # lcov_find(dir, function, data[, extension, ...)])
 #
 # Search DIR for files and directories whose name matches PATTERN and run
-# FUNCTION for each match. If not pattern is specified, match all names.
+# FUNCTION for each match. If no pattern is specified, match all names.
 #
 # FUNCTION has the following prototype:
 #   function(dir, relative_name, data)

--- a/lcovrc
+++ b/lcovrc
@@ -32,6 +32,10 @@ genhtml_med_limit = 75
 # See man pages for list of ignorable messsages
 #ignore_errors = empty,mismatch
 
+# Stop emitting message after this number have been printed
+# 0 == no limit
+max_message_count = 100
+
 # If set, do not stop when an 'ignorable error' occurs - try to generate
 #  a result, however flawed.  This is equivalent to the '--keep-going'
 #  command line switch.

--- a/man/genhtml.1
+++ b/man/genhtml.1
@@ -1105,7 +1105,11 @@ branch ID (2nd field in the .info file 'BRDA' entry) does not follow expected in
 .B category:
 line number categorizations are incorrect in the .info file, so branch coverage line number turns out to not be an executable source line.
 
-.B corrup:t
+.B count:
+An excessive number of messages of some class have been reported - subsequent messaages of that type will be suppressed.
+The limit can be controlled by the 'max_message_count' variable. See the lcovrc man page.
+
+.B corrupt:
 corrupt/unreadable file found.
 
 .B empty:
@@ -1121,6 +1125,11 @@ Files have been moved or repository history presented by '\-\-diff\-file' data i
 Inconsistent entries found in trace file:
  - branch expression (3rd field in the .info file 'BRDA' entry) of merge data does not match, or
  - function execution count (FNDA:...) but no function declaration (FN:...).
+
+.B negative:
+negative 'hit' count found.
+.br
+ Note that negative counts may be caused by a knwon GCC bug - see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080, and try compiling with "-fprofile-update=atomic". (You will need to recompile, re-run your tests, and re-capture coverage data.)
 
 .B package:
 a required perl package is not installed on your system.  In some cases, it is possible to ignore this message and continue - however, certain features will be disabled in that case.
@@ -1143,6 +1152,8 @@ the include/exclude/substitute/omit pattern did not match any file pathnames.
 .B version:
 \-\-version\-script comparison returned non\-zero mismatch indication.  It likely that the version of the file which was used in coverage data extraction is different than the source version which was found.  File annotations may be incorrect.
 
+.br
+Also see man lcovrc for a discussion of the 'max_message_count' parameter which can be used to control the number of warnings which are emitted before all subsequent messages are suppressed.  This can be used to reduce log file volume.
 
 .RE
 .BI "\-\-keep\-going "

--- a/man/geninfo.1
+++ b/man/geninfo.1
@@ -491,6 +491,10 @@ branch ID (2nd field in the .info file 'BRDA' entry) does not follow expected in
 .B corrupt:
 corrupt/unreadable file found.
 
+.B count:
+An excessive number of messages of some class have been reported - subsequent messaages of that type will be suppressed.
+The limit can be controlled by the 'max_message_count' variable. See the lcovrc man page.
+
 .B empty:
 the .info data file is empty (e.g., because all the code was 'removed' or excluded.
 
@@ -508,6 +512,11 @@ Inconsistent entries found in trace file:
  - branch expression (3rd field in the .info file 'BRDA' entry) of merge data does not match, or
  - function execution count (FNDA:...) but no function declaration (FN:...).
 
+.B negative:
+negative 'hit' count found.
+.br
+ Note that negative counts may be caused by a knwon GCC bug - see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080, and try compiling with "-fprofile-update=atomic". (You will need to recompile and re-run your tests.)
+
 .B package:
 a required perl package is not installed on your system.  In some cases, it is possible to ignore this message and continue - however, certain features will be disabled in that case.
 
@@ -522,6 +531,9 @@ the include/exclude/omit/substitute pattern did not match any file pathnames.
 
 .B version:
 revision control IDs of the file which we are trying to merge are not the same - line numbering and other information may be incorrect.
+
+.br
+Also see man lcovrc for a discussion of the 'max_message_count' parameter which can be used to control the number of warnings which are emitted before all subsequent messages are suppressed.  This can be used to reduce log file volume.
 
 .RE
 .BI "\-\-keep\-going "

--- a/man/lcov.1
+++ b/man/lcov.1
@@ -835,6 +835,10 @@ branch ID (2nd field in the .info file 'BRDA' entry) does not follow expected in
 .B corrupt:
 corrupt/unreadable file found.
 
+.B count:
+An excessive number of messages of some class have been reported - subsequent messaages of that type will be suppressed.
+The limit can be controlled by the 'max_message_count' variable. See the lcovrc man page.
+
 .B empty:
 the .info data file is empty (e.g., because all the code was 'removed' or excluded.
 
@@ -852,6 +856,11 @@ Inconsistent entries found in trace file:
  - branch expression (3rd field in the .info file 'BRDA' entry) of merge data does not match, or
  - function execution count (FNDA:...) but no function declaration (FN:...).
 
+.B negative:
+negative 'hit' count found.
+.br
+ Note that negative counts may be caused by a knwon GCC bug - see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080, and try compiling with "-fprofile-update=atomic". (You will need to recompile and re-run your tests.)
+
 .B package:
 a required perl package is not installed on your system.  In some cases, it is possible to ignore this message and continue - however, certain features will be disabled in that case.
 
@@ -866,6 +875,9 @@ the include/exclude/omit/substitute pattern did not match any file pathnames.
 
 .B version:
 revision control IDs of the file which we are trying to merge are not the same - line numbering and other information may be incorrect.
+
+.br
+Also see man lcovrc for a discussion of the 'max_message_count' parameter which can be used to control the number of warnings which are emitted before all subsequent messages are suppressed.  This can be used to reduce log file volume.
 
 
 .RE

--- a/man/lcovrc.5
+++ b/man/lcovrc.5
@@ -153,6 +153,12 @@ genhtml_med_limit = 75
 #ignore_errors = empty,mismatch
 .br
 
+# Stop emitting message after this number have been printed
+.br
+# 0 == no limit
+.br
+max_message_count = 100
+
 .br
 # If set, do not stop when an 'ignorable error' occurs - try
 .br
@@ -607,6 +613,18 @@ Specify a  message type which should be ignored.
 This option can be used multiple times in the lcovrc file to ignore multiple message types.
 
 This option is equivalent to the \-\-ignore\-errors option to geninfo, genhtml, or lcov.  Note that the lcovrc file message list is not applied (those messages NOT ignored) if the '\-\-ignore\-errors' command line option is specified.
+.br
+This option is used by genhtml, lcov, and geninfo.
+
+.PP
+
+.BR max_message_count " ="
+.IR integer
+.IP
+Set the maximum number of warnings of any particular type which should be emitted. This can be used to reduce the size of log files.
+.br
+
+No more warnings will be printed after this number is reached.  0 (zero) is interpreted as 'no limit'.
 .br
 This option is used by genhtml, lcov, and geninfo.
 


### PR DESCRIPTION
Handle negative hit/taken values - typically caused by gcc bug: see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080
Add message type 'count', and add feature to suppress additional messages after threshold is excceeded.
If user is not going to fix the first N messages, then there is no point to reporting more.

Signed-off-by:  Henry Cox <henry.cox@mediatek.com>