### PR TITLE
Incorrect genhtml man description

### DIFF
--- a/man/genhtml.1
+++ b/man/genhtml.1
@@ -1218,7 +1218,7 @@ Specify whether to display branch coverage data in HTML output.
 
 Use \-\-branch\-coverage to enable branch coverage display or
 \-\-no\-branch\-coverage to disable it. Branch coverage data display is
-.B enabled
+.B disabled
 by default
 
 When branch coverage display is enabled, each overview page will contain


### PR DESCRIPTION
Updated genhtml docs to correctly show branch coverage is disabled by default.

Signed-off-by: Jake Leventhal [jakeleventhal@me.com](mailto:jakeleventhal@me.com)