### PR TITLE
Fix bug in genhtml when identifying new code in functions

### DIFF
--- a/bin/genhtml
+++ b/bin/genhtml
@@ -2906,7 +2906,7 @@ sub _categorizeFunctionCov
                     } else {
                         # line is same
                         my $bline =
-                            $linemap->lookup($filename, $linemap->OLD, $line);
+                            $linemap->lookup($filename, $linemap->NEW, $line);
                         if (defined($lineCovBase->value($bline)) ^
                             defined($lineCovCurrent->value($line))) {
                             $changed = 1;


### PR DESCRIPTION
In this portion of code, $line is referring to the line in the current code (i.e. $linemap->NEW). Therefore, when using $linemap->lookup, we should indicate this instead.