### PR TITLE
Update README: installation instructions

### DIFF
--- a/README
+++ b/README
@@ -140,7 +140,7 @@ These perl packages include:
 If your system is missing any of these, then you may be able to install them
 via:
 
-   $ perl -MCPAN -e 'install "packageName"'
+   $ perl -MCPAN -e 'install(<packageName>)'
 
 You will very likely need superuser access to be able to install Perl
 modules.


### PR DESCRIPTION
The readme installation instructions contain a command that does not work for some of the packages lcov depends on. For instance, trying to install `Scalar::Util` as per current suggested command (perl -MCPAN -e "install Scalar::Util") will result in:  Can't locate object method "install" via package "Scalar::Util" at -e line 1.

Additionally, the maintainers might want to offer a one-liner to install all the perl packages at once:

```bash
for package in Capture::Tiny DateTime Devel::Cover Digest::MD5 File::Spec \
    JSON Memory::Process Module::Load::Conditional Scalar::Util Time::HiRes; \
    do yes "yes" | perl -MCPAN -e "install(${package})"; done
```