### PR TITLE
Bugfix: typo in geninfo.1

### DIFF
--- a/man/geninfo.1
+++ b/man/geninfo.1
@@ -1174,7 +1174,7 @@ option is supplied, then
 .RS
  #comment_string
 .RE
-will appeaare at the top of the tracefile.  There is no space before or after the
+will appear at the top of the tracefile.  There is no space before or after the
 .I #
 character.
 


### PR DESCRIPTION
This commit fixes a very small typo in `geninfo(1)`.

Noticed this while writing a parser for `.info` files. The documentation looks perfect otherwise so I figured this warranted the effort of a PR on my part.

`lcov` is an excellent tool, thank you for putting in the effort to maintain it.