### PR TITLE
Escape function aliases, which may be templates

### DIFF
--- a/bin/genhtml
+++ b/bin/genhtml
@@ -12590,6 +12590,10 @@ END_OF_HTML
                         $tla;
                     $tlaRow = "<td class=\"tla$tla\">$label</td>";
                 }
+
+                # Escape special characters
+                $alias = escape_html($alias);
+
                 write_html(*HTML_HANDLE, <<END_OF_HTML);
             <tr>
               <td class="coverFnAlias"><a href="$source#L$startline">$alias</a></td>


### PR DESCRIPTION
For a function templated on `T` returning an `boost::optional<T>`, I am seeing many repeated incomplete function signatures on the "functions" page for a header file. On inspecting the HTML, each represents a unique specialization of the template, but because the angle brackets aren't escaped, template parameters are eaten by the HTML parser and each line looks the same, missing those template parameters.

The accompanying change appears to address this issue.