### PR TITLE
tests: Fix stray ")" in test script `py2lcov.sh`

### DIFF
--- a/tests/py2lcov/py2lcov.sh
+++ b/tests/py2lcov/py2lcov.sh
@@ -97,7 +97,7 @@ fi
 git -C . rev-parse > /dev/null 2>&1
 if [ 0 == $? ] ; then
     # this is git
-    VERSION="--version-script ${SCRIPT_DIR}/gitversion${MD5_OPT)}"
+    VERSION="--version-script ${SCRIPT_DIR}/gitversion${MD5_OPT}"
     ANNOTATE="--annotate-script ${SCRIPT_DIR}/gitblame.pm,--cache,my_cache"
 else
     VERSION="--version-script ${SCRIPT_DIR}/P4version.pm,--local-edit${MD5_OPT}"


### PR DESCRIPTION
Symptom was:

```console
# sudo make install PREFIX=/usr CFG_DIR=/etc
[..]
./py2lcov.sh: line 100: --version-script ${SCRIPT_DIR}/gitversion${MD5_OPT)}: bad substitution
[..]                                                                      ^
```

Regression from commit 747a891ce66cf19c6fe7cf4832738beeeb584ec9