### PR TITLE
`lib/lcovutil.pm`: Fix `->filename` access in `_deriveFunctionEndLines`

### DIFF
--- a/lib/lcovutil.pm
+++ b/lib/lcovutil.pm
@@ -7109,7 +7109,7 @@ sub _deriveFunctionEndLines
                         );
                         lcovutil::ignorable_error(
                             $lcovutil::ERROR_INCONSISTENT_DATA,
-                            '"' . $traceInfo->filenname() .
+                            '"' . $traceInfo->filename() .
                                 "\":$first:  function " . $func->name() .
                                 ": last line in file is not last line of function.$suffix"
                         );


### PR DESCRIPTION
```console
# git --no-pager grep 'traceInfo->filename'
bin/genhtml:        my $filename  = ReadCurrentSource::resolve_path($traceInfo->filename());
lib/lcovutil.pm:                        '"' . $traceInfo->filename() .
lib/lcovutil.pm:                            '"' . $traceInfo->filename() .
lib/lcovutil.pm:                    '"' . $traceInfo->filename() .
lib/lcovutil.pm:                           '"' . $traceInfo->filename() .
lib/lcovutil.pm:    $lcovutil::profileData{derive_end}{$traceInfo->filename()} = $end - $start;
lib/lcovutil.pm:                         '"' . $traceInfo->filename() .
lib/lcovutil.pm:                           '"' . $traceInfo->filename() .
lib/lcovutil.pm:        !TraceFile::is_language('perl', $traceInfo->filename());
lib/lcovutil.pm:                      '"' . $traceInfo->filename() .
lib/lcovutil.pm:                    '"' . $traceInfo->filename() .
lib/lcovutil.pm:                    '"' . $traceInfo->filename() .
lib/lcovutil.pm:    $lcovutil::profileData{check_consistency}{$traceInfo->filename()} =
lib/lcovutil.pm:        my $source_file = $traceInfo->filename();
```