### PR TITLE
`py2lcov` and `xml2lcov`: Fix command injection from `subprocess.run([..], shell=True, [..])` (fixes #350)

### DIFF
--- a/bin/py2lcov
+++ b/bin/py2lcov
@@ -191,10 +191,12 @@ Example:
         while os.path.exists(xml):
             xml = base + '.xml%d' % suffix
             suffix += 1
-        cmd = "COVERAGE_FILE='%s' '%s' xml -o '%s'" % (f, args.cover_cmd, xml)
+        env = os.environ.copy()
+        env["COVERAGE_FILE"] = f
+        cmd = [args.cover_cmd, "xml", "-o", xml]
         try:
-            #x = subprocess.run(cmd, capture_output=True, shell=True, check=True)
-            x = subprocess.run(cmd, shell=True, check=True, stdout=True, stderr=True)
+            #x = subprocess.run(cmd, capture_output=True, shell=False, check=True, env=env)
+            x = subprocess.run(cmd, shell=False, check=True, stdout=True, stderr=True, env=env)
         except subprocess.CalledProcessError as err:
             print("Error:  error during XML conversion of %s: %s" % (
                 f, str(err)));

--- a/bin/xml2lcovutil.py
+++ b/bin/xml2lcovutil.py
@@ -121,8 +121,9 @@ This is a problem in at least 2 ways:
         self._outf.close()
 
         if self._args.version and None == self._versionScript:
+            lcov = os.path.join(os.path.split(sys.argv[0])[0], 'lcov')
             cmd = "'%(lcov)s' -a '%(info)s' -o '%(info)s' --version-script '%(vers)s' %(checksum)s--rc compute_file_version=1 --branch-coverage --ignore inconsistent" % {
-                'lcov': os.path.join(os.path.split(sys.argv[0])[0], 'lcov'),
+                'lcov': lcov,
                 'checksum': "--checksum " if self._args.checksum else '',
                 'info': self._args.output,
                 'vers' : self._args.version,

--- a/bin/xml2lcovutil.py
+++ b/bin/xml2lcovutil.py
@@ -122,14 +122,18 @@ This is a problem in at least 2 ways:
 
         if self._args.version and None == self._versionScript:
             lcov = os.path.join(os.path.split(sys.argv[0])[0], 'lcov')
-            cmd = "'%(lcov)s' -a '%(info)s' -o '%(info)s' --version-script '%(vers)s' %(checksum)s--rc compute_file_version=1 --branch-coverage --ignore inconsistent" % {
-                'lcov': lcov,
-                'checksum': "--checksum " if self._args.checksum else '',
-                'info': self._args.output,
-                'vers' : self._args.version,
-            }
+            cmd = [
+                lcov,
+                "-a", self._args.output,
+                "-o", self._args.output,
+                "--version-script", self._args.version,
+                *(["--checksum"] if self._args.checksum else []),
+                "--rc", "compute_file_version=1",
+                "--branch-coverage",
+                "--ignore", "inconsistent",
+            ]
             try:
-                x = subprocess.run(cmd, shell=True, check=True, stdout=True, stderr=True)
+                x = subprocess.run(cmd, shell=False, check=True, stdout=True, stderr=True)
             except subprocess.CalledProcessError as err:
                 print("Error during lcov version append operation: %s" % (
                     str(err)))


### PR DESCRIPTION
Fixes #350