### PR TITLE
Add '--filter mcdc' option - to remove MC/DC coverpoints which are

### DIFF
--- a/man/genhtml.1
+++ b/man/genhtml.1
@@ -2236,6 +2236,13 @@ Exclude lines which appear to be part of a C++ std::initializer_list.
 alias for "\-\-filter brace,blank".
 .PP
 
+.IP mcdc: 3
+Remove MC/DC coverpoint which contains single expression, if 'branch' coverpoint
+is present on the same line.
+Singe-element MC/DC coverpoints are identical to the corresponding branch - except
+in the case of compile-time expression evaluation, for example, in a template
+function.
+
 .IP orphan: 3
 Remove branches which appear by themselves -
 .I i.e.,

--- a/tests/lcov/mcdc/main.cpp
+++ b/tests/lcov/mcdc/main.cpp
@@ -21,4 +21,3 @@ int main(int ac, char ** av)
 #endif
   return 0;
 }
-

--- a/tests/lcov/mcdc/test.cpp
+++ b/tests/lcov/mcdc/test.cpp
@@ -8,9 +8,13 @@
 
 void test(int a, int b, int c)
 {
-  if (a && (b || c)) {
+  if
+#ifdef SIMPLE
+    (a)
+#else
+    (a && (b || c))
+#endif
     printf("%d && (%d || %d)\n", a, b, c);
-  } else {
+  else
     printf("not..\n");
-  }
 }


### PR DESCRIPTION
identical to the corresponding branch:  reduce verbosity/noise.