### PR TITLE
'lcov --capture' interface change:  apply 'region' and 'branch_region…

### DIFF
--- a/bin/geninfo
+++ b/bin/geninfo
@@ -427,9 +427,21 @@ if ($lcovutil::mcdc_coverage) {
 # Determine compatibility modes
 parse_compat_modes($lcovutil::geninfo_opt_compat);
 
-unless ($no_markers) {
+if ($no_markers) {
+    lcovutil::ignorable_error($lcovutil::ERROR_USAGE,
+                   "use new '--filter' option or old '--no-markers' - not both")
+        if (@lcovutil::opt_filter);
+} elsif (!@lcovutil::opt_filter) {
+    # don't apply the backward-compatible options if user specifies any filters
+    lcovutil::info(1,
+        "$lcovutil::tool_name:  applying '--filter region,branch_region' by default - see the '--no-markers' section in the man page for more information.\n"
+    );
     push(@lcovutil::opt_filter, "region");
     push(@lcovutil::opt_filter, "branch_region") if $br_coverage;
+} else {
+    lcovutil::info(
+        "Note: 'region' and 'branch_region' filters are not applied by default when '--filter' is specified.  See the '--no-markers section in the man page for more information.\n"
+    ) unless grep({ /(region|branch_region)/ } @lcovutil::opt_filter);
 }
 parse_cov_filters(@lcovutil::opt_filter);
 

--- a/man/geninfo.1
+++ b/man/geninfo.1
@@ -1135,8 +1135,24 @@ entry in
 .B \-\-no\-markers
 .br
 .RS
+Unless the
+.I \-\-no\-markers
+option is used,
+.BR geninfo
+will apply both
+.I region
+and
+.I branch_region
+filters to the captured coverae data.
 Use this option if you want to get coverage data without regard to exclusion
 markers in the source code file.
+
+If any
+.I \-\-filter
+options are applied, then the default region filters are not used.
+
+.I \-\-no\-markers should not be specified along with
+.I \-\-filter.
 .RE
 
 .B \-\-no\-recursion

--- a/tests/gendiffcov/errs/msgtest.sh
+++ b/tests/gendiffcov/errs/msgtest.sh
@@ -285,6 +285,23 @@ if [ 0 != $? ] ; then
     fi
 fi
 
+echo geninfo $LCOV_OPTS --no-markers --filter branch . -o usage1.info --msg-log markers.err
+$GENINFO_TOOL $LCOV_OPTS --no-markers --filter branch . -o usage1.info --msg-log markers.err
+if [ 0 == $? ] ; then
+    echo "ERROR: expected usage error"
+    if [ 0 == $KEEP_GOING ] ; then
+        exit 1
+    fi
+fi
+grep "use new '--filter' option or old" markers.err
+if [ 0 != $? ] ; then
+    echo "ERROR: didint find usage error"
+    if [ 0 == $KEEP_GOING ] ; then
+        exit 1
+    fi
+fi
+
+
 echo lcov $LCOV_OPTS --summary initial.info --config-file noSuchFile --ignore usage
 $COVER $LCOV_TOOL $LCOV_OPTS --summary initial.info --config-file noSuchFile --ignore usgae 2>&1 | tee err_missing.log
 grep "cannot read configuration file 'noSuchFile'" err_missing.log


### PR DESCRIPTION
…' default filters only if '--filter ...' option was not used.

Error if both '--filter' and '--no-markers' are specified (or or the other - not both). Action is unchanged (filter out excluded regions) if no filter options are specified.