### PR TITLE
'genhtml --date-labels string[,string...]' option - to specify label

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 -------------------------------------------------
 - README file for the LTP GCOV extension (LCOV) -
-- Last changes: 2024-11-26
+- Last changes: 2024-12-16
 -------------------------------------------------
 
 Description
@@ -313,7 +313,8 @@ LCOV features and capabilities fall into 7 major categories:
 
      Related options:
         --baseline-file, --diff-file, --annotate-script, --select-script
-        --date-bins, --new-file-as-baseline, --elide-path-mismatch
+        --date-bins, --date-labels --new-file-as-baseline,
+        --elide-path-mismatch
 
   b) Error handling
 

--- a/bin/genhtml
+++ b/bin/genhtml
@@ -424,9 +424,19 @@ sub noBaseline
 sub setAgeGroups
 {
     #my $numGroups = scalar(@_) + 1;
-    @cutpoints      = sort({ $a <=> $b } @_);
+    @cutpoints = sort({ $a <=> $b } @_);
+    if (@ageGroupHeader) {
+        # labels were specified by user
+        @ageGroupHeader = split($lcovutil::split_char,
+                                join($lcovutil::split_char, @ageGroupHeader));
+        goto done
+            if (scalar(@ageGroupHeader) == scalar(@cutpoints) + 1);
+        # mismatched number - generate warning
+        lcovutil::ignorable_error($lcovutil::ERROR_USAGE,
+               "expected number of 'age' labels to match 'date-bin' cutpoints");
+        # if message ignored, then assign default labels
+    }
     @ageGroupHeader = ();
-    %ageHeaderToBin = ();
     my $prefix = "[..";
     foreach my $days (@cutpoints) {
         my $header = $prefix . $days . "] days";
@@ -434,6 +444,8 @@ sub setAgeGroups
         $prefix = "(" . $days . ",";
     }
     push(@ageGroupHeader, "(" . $cutpoints[-1] . "..) days");
+    done:
+    %ageHeaderToBin = ();
     my $bin = 0;
     foreach my $header (@ageGroupHeader) {
         $ageHeaderToBin{$header} = $bin;
@@ -6851,7 +6863,7 @@ STDERR->autoflush;
 STDOUT->autoflush;
 
 my @datebins;
-my (@rc_date_bins, @rc_annotate_script, @rc_select_script);
+my (@rc_date_bins, @rc_annotate_script, @rc_select_script, @rc_date_labels);
 
 my %genhtml_rc_opts = (
                "genhtml_css_file"            => \$css_filename,
@@ -6909,6 +6921,7 @@ my %genhtml_rc_opts = (
                "select_script"               => \@rc_select_script,
                'num_context_lines' => \$InInterestingRegion::num_context_lines,
                'genhtml_date_bins' => \@rc_date_bins,
+               'genhtml_date_labels'        => \@rc_date_labels,
                'truncate_owner_table'       => \@truncateOwnerTableLevels,
                'owner_table_entries'        => \$ownerTableElements,
                'compact_summary_tables'     => \$compactSummaryTables,
@@ -6944,6 +6957,7 @@ my %genhtml_options = ("output-directory|o=s" => \$output_directory,
                        'show-zero-columns' => \$show_zeroTlaColumns,
                        'simplified-colors' => \$show_simplifiedColors,
                        "date-bins=s"       => \@datebins,
+                       'date-labels=s'     => \@SummaryInfo::ageGroupHeader,
                        "prefix|p=s"        => \@opt_dir_prefix,
                        "num-spaces=i"      => \$tab_size,
                        "no-prefix"         => \$no_prefix,
@@ -7003,6 +7017,7 @@ $mcdc_med_limit = $med_limit if (!defined($mcdc_med_limit));
 $frames         = undef unless (defined($frames) && $frames);
 
 foreach my $rc ([\@datebins, \@rc_date_bins],
+                [\@SummaryInfo::ageGroupHeader, \@rc_date_labels],
                 [\@SourceFile::annotateScript, \@rc_annotate_script],
                 [\@selectCallbackScript, \@rc_select_script]
 

--- a/bin/geninfo
+++ b/bin/geninfo
@@ -1893,12 +1893,10 @@ sub process_dafile($$$$)
                             );
                             if ($lcovutil::opt_adjust_unexecuted_blocks) {
                                 $hit = 0;
-                            } elsif (
-                                     lcovutil::warn_once(
+                            } elsif (lcovutil::warn_once(
                                                         "unexecuted block",
                                                         $ERROR_INCONSISTENT_DATA
-                                     )
-                            ) {
+                            )) {
                                 lcovutil::ignorable_warning(
                                     $ERROR_INCONSISTENT_DATA,
                                     "$source_filename:$line_number: unexecuted block on non-branch line with non-zero hit count.  Use \"geninfo --rc geninfo_unexecuted_blocks=1 to set count to zero."

--- a/man/genhtml.1
+++ b/man/genhtml.1
@@ -163,6 +163,9 @@ genhtml \- Generate HTML view from LCOV coverage data files
 .RB [ \-\-date\-bins
 .IR day[,day,...]]
 .br
+.RB [ \-\-date\-labels
+.IR string[,string,...]]
+.br
 .RB [ \-\-show\-owners
 .IR [ all ] ]
 .br
@@ -1937,7 +1940,39 @@ for details.
 .RS
 The
 .B \-\-date\-bins
-option is used to specify age boundaries (cutpoints) for date\-binning classification.  If not specified, the default is to use 4 age ranges: less than 7 days, 7 to 30 days, 30 to 180 days, and more than 180 days.
+option is used to specify age boundaries (cutpoints) for date\-binning classification.  Each
+.I age
+element is expected to be an integer number of days prior to today (or SOURCE_DATE_EPOCH, if specified).  If not specified, the default is to use 4 age ranges: less than 7 days, 7 to 30 days, 30 to 180 days, and more than 180 days.
+This option is equivalent to the
+.I genhtml_date_bins
+config file option.  See man
+.B lcovrc(5).
+
+This argument has no effect if there is no
+.I source\-annotation\-script .
+
+.RE
+.BI "\-\-date\-labels " string[,string,...]
+.RS
+The
+.B \-\-date\-labels
+option is used to specify labels used for the 'date\-bin' table entries in the HTML report.
+.br
+The number of labels should be one greater than the number of cutpoints.
+.br
+If not specified, the default is to use label strings which specify the
+.I [from ..to)
+range of ages held by the corresponding bin.
+
+One possible use of this option is to use release names in the tables -
+.I i.e.,
+to indicate the release in which each particular line first appeared.
+
+This option is equivalent to the
+.I genhtml_date_labels
+config file option.  See man
+.B lcovrc(5).
+
 This argument has no effect if there is no
 .I source\-annotation\-script .
 

--- a/man/lcovrc.5
+++ b/man/lcovrc.5
@@ -2647,10 +2647,24 @@ The default is 20.
 .IR integer[,integer..]
 .IP
 This option is equivalent to the "genhtml \-\-date\-bins" option.
-See the genhtml man page for details.
+See man
+.B genhtml(1)
+for details.
 
 This option can be used multiple times in the lcovrc file to set multiple cutpoints.
-The cutpoints specified in the lcovrc file are appended to the cutpoints (if any) specified on the command line.
+
+.PP
+
+.BR genhtml_datelabels " ="
+.IR string[,string..]
+.IP
+This option is equivalent to the "genhtml \-\-date\-labels" option.
+See man
+.B genhtml(1)
+for details.
+
+This option can be used multiple times in the lcovrc file to set multiple labels.
+The number of labels should equal one greater than number of cutpoints.
 
 .PP
 

--- a/tests/gendiffcov/errs/msgtest.sh
+++ b/tests/gendiffcov/errs/msgtest.sh
@@ -133,7 +133,7 @@ LCOV_OPTS="$LCOV_BASE"
 DIFFCOV_OPTS="--filter line,branch,function --function-coverage --branch-coverage --demangle-cpp --prefix $PARENT_VERSION $PROFILE "
 
 rm -f test.cpp *.gcno *.gcda a.out *.info *.log *.json diff.txt
-rm -rf select criteria annotate empty unused_src scriptErr scriptFixed epoch inconsistent highlight etc mycache cacheFail expect subset context
+rm -rf select criteria annotate empty unused_src scriptErr scriptFixed epoch inconsistent highlight etc mycache cacheFail expect subset context labels
 
 if [ "x$COVER" != 'x' ] && [ 0 != $LOCAL_COVERAGE ] ; then
     cover -delete
@@ -765,6 +765,22 @@ fi
 grep -E "WARNING: .*callback.* evaluation of .+ failed" expect.log
 if [ 0 != $? ] ; then
     echo "ERROR: didn't find expected callback message"
+    if [ 0 == $KEEP_GOING ] ; then
+        exit 1
+    fi
+fi
+
+# generate error for case that number of date labels doesn't match
+$COVER $GENHTML_TOOL $DIFFCOV_OPTS initial.info -o labels --annotate $ANNOTATE_SCRIPT --baseline-file initial.info --title 'context' --header-title 'this is the header' --date-bins 1,5,22 --date-labels a,b,c,d,e --baseline-date "$NOW" --msg-log labels.log
+if [ 0 == $? ] ; then
+    echo "ERROR: genhtml --date-labels didn't fail"
+    if [ 0 == $KEEP_GOING ] ; then
+        exit 1
+    fi
+fi
+grep -E "ERROR: .*usage.* expected number of 'age' labels to match" labels.log
+if [ 0 != $? ] ; then
+    echo "ERROR: didn't find expected labels message"
     if [ 0 == $KEEP_GOING ] ; then
         exit 1
     fi


### PR DESCRIPTION
for corresponding 'date' table entries in HTML report.