### PR TITLE
Do not remove '/usr/bin/env ...' paths in scripts.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ install:
 		$(INSTALL) -m 755 bin/$$b $(BIN_INST_DIR)/$$b ; \
 		$(FIX) --version $(VERSION) --release $(RELEASE) \
 		       --libdir $(LIB_DIR) --bindir $(BIN_DIR) \
-		       --fixinterp --fixver --fixlibdir --fixbindir \
+		       --fixver --fixlibdir --fixbindir \
 		       --exec $(BIN_INST_DIR)/$$b ; \
 	done
 	$(INSTALL) -d -m 755 $(SCRIPT_INST_DIR)
@@ -131,7 +131,7 @@ install:
 		$(INSTALL) -m 755 scripts/$$s $(SCRIPT_INST_DIR)/$$s ; \
 		$(FIX) --version $(VERSION) --release $(RELEASE) \
 		       --libdir $(LIB_DIR) --bindir $(BIN_DIR) \
-		       --fixinterp --fixver --fixlibdir \
+		       --fixver --fixlibdir \
 		       --fixscriptdir --scriptdir $(SCRIPT_DIR) \
 		       --exec $(SCRIPT_INST_DIR)/$$s ; \
 	done
@@ -141,7 +141,7 @@ install:
 		$(INSTALL) -m 644 lib/$$l $(LIB_INST_DIR)/$$l ; \
 		$(FIX) --version $(VERSION) --release $(RELEASE) \
 		       --libdir $(LIB_DIR) --bindir $(BIN_DIR) \
-		       --fixinterp --fixver --fixlibdir --fixbindir \
+		       --fixver --fixlibdir --fixbindir \
 		       --exec $(LIB_INST_DIR)/$$l ; \
 	done
 	for section in 1 5 ; do \

--- a/bin/fix.pl
+++ b/bin/fix.pl
@@ -100,7 +100,8 @@ sub update_perl($)
     }
 
     if ($opt_fixinterp && defined($path) && $path ne "") {
-        $source =~ s/^#!.*perl.*\n/#!$path\n/;
+        $source =~ s/^#!.*perl.*\n/#!$path\n/
+            unless $source =~ @^#!/usr/bin/env perl$@;
     }
 
     if ($opt_fixlibdir) {
@@ -133,7 +134,8 @@ sub update_python($)
     my $path = $ENV{"LCOV_PYTHON_PATH"};
 
     if ($opt_fixinterp && defined($path) && $path ne "") {
-        $source =~ s/^#!.*python.*\n/#!$path\n/;
+        $source =~ s/^#!.*python.*\n/#!$path\n/
+            unless $source =~ @^#!/usr/bin/env python3?$@;
     }
 
     return $source;


### PR DESCRIPTION
If user explicitly asks to use a particular verion (...by having it in her environment):  use it.

Signed-off-by:  Henry Cox <henry.cox@mediatek.com>