### PR TITLE
Pass the --tempdir option from lcov to geninfo

### DIFF
--- a/bin/lcov
+++ b/bin/lcov
@@ -916,7 +916,8 @@ sub lcov_geninfo(@)
     push(@param, "--mcdc") if $lcovutil::mcdc_coverage;
     push(@param, '--fail-under-lines', $lcovutil::fail_under_lines)
         if defined($lcovutil::fail_under_lines);
-
+    push(@param, '--tempdir', $lcovutil::tempdirname)
+        if (defined($lcovutil::tempdirname));
     foreach my $listOpt (['--comment', \@lcovutil::comments],
                          ['--config-file', \@lcovutil::opt_config_files],
                          ['--rc', \@lcovutil::opt_rc],

--- a/lib/lcovutil.pm
+++ b/lib/lcovutil.pm
@@ -1071,7 +1071,7 @@ my (@rc_filter, @rc_ignore, @rc_exclude_patterns,
     $rc_no_branch_coverage, $rc_no_func_coverage, $rc_no_checksum,
     $version);
 my $quiet = 0;
-my $tempdirname;
+our $tempdirname;
 
 # these options used only by lcov - but moved here so that we can
 #   share arg parsing


### PR DESCRIPTION
lcov invokes geninfo but didn't provide it with the user's --tempdir option value (if specified); pass it down.