### PR TITLE
Make extraction tests work without `${USER}` (fixes #378)

### DIFF
--- a/tests/lcov/extract/extract.sh
+++ b/tests/lcov/extract/extract.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set +x
 
+: ${USER:="$(id -u -n)"}
+
 source ../../common.tst
 
 rm -rf *.gcda *.gcno a.out *.info* *.txt* *.json dumper* testRC *.gcov *.gcov.* *.log *.o errs *.msg *.dat

--- a/tests/lcov/extract/extract.sh
+++ b/tests/lcov/extract/extract.sh
@@ -217,7 +217,7 @@ if [ 0 != $? ] ; then
     fi
 fi
 
-grep -E "\"user\":\"$USER\"" context.info.json
+grep -F "\"user\":\"$USER\"" context.info.json
 if [ 0 != $? ] ; then
     echo "Error:  did not find expected context field"
     if [ $KEEP_GOING == 0 ] ; then
@@ -241,7 +241,7 @@ if [ 0 != $? ] ; then
     fi
 fi
 
-grep -E "\"user\":\"$USER\"" context.info.json
+grep -F "\"user\":\"$USER\"" context.info.json
 if [ 0 != $? ] ; then
     echo "Error:  did not find expected context field"
     if [ $KEEP_GOING == 0 ] ; then


### PR DESCRIPTION
## Before

```console
# USER= make -C tests/lcov/extract/ check 
make: Entering directory '[..]/tests/lcov/extract'
Starting tests
lcov/extract/extract.sh ........... [fail] (time 4.7s, mem 58.8MB)
    Skipping 228 previous lines (see [..]/tests//test.log)
    ...
      functions...: 28.6% (2 of 7 functions)
      branches....: 33.3% (8 of 24 branches)
    Filter suppressions:
      region:
        2 instances
        5 coverpoints
    Message summary:
      no messages were reported
    Error:  did not find expected context field
  EXITCODE ...: 1
1 tests executed, 0 passed, 1 failed, 0 skipped (time 4.7s, mem 58.8MB)
Result log stored in [..]/tests/test.log
make: *** [../../common.mak:116: check] Error 1
make: Leaving directory '[..]/tests/lcov/extract'
```


## After

```console
# USER= make -C tests/lcov/extract/ check 
make: Entering directory '[..]/tests/lcov/extract'
Starting tests
lcov/extract/extract.sh ........... [pass] (time 23.1s, mem 58.9MB)
1 tests executed, 1 passed, 0 failed, 0 skipped (time 23.1s, mem 58.9MB)
Result log stored in [..]/tests/test.log
make: Leaving directory '[..]/tests/lcov/extract'
```