### PR TITLE
Fix aggressive "rm -rf" in uninstall target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ CFG_DIR := $(PREFIX)/etc
 BIN_DIR := $(PREFIX)/bin
 LIB_DIR := $(PREFIX)/lib/lcov
 MAN_DIR := $(PREFIX)/share/man
-SHARE_DIR := $(PREFIX)/share/lcov/
+SHARE_DIR := $(PREFIX)/share/lcov
 SCRIPT_DIR := $(SHARE_DIR)/support-scripts
 
 CFG_INST_DIR := $(DESTDIR)$(CFG_DIR)
@@ -159,8 +159,8 @@ install:
 	mkdir -p $(SHARE_INST_DIR)
 	for d in example tests ; do \
 		( cd $$d ; make clean ) ; \
-		find $$d -type d -exec mkdir -p "$(SHARE_INST_DIR){}" \; ; \
-		find $$d -type f -exec $(INSTALL) -Dm 644 "{}" "$(SHARE_INST_DIR){}" \; ; \
+		find $$d -type d -exec mkdir -p "$(SHARE_INST_DIR)/{}" \; ; \
+		find $$d -type f -exec $(INSTALL) -Dm 644 "{}" "$(SHARE_INST_DIR)/{}" \; ; \
 	done ;
 	@chmod -R ugo+x $(SHARE_INST_DIR)/tests/bin
 	@find $(SHARE_INST_DIR)/tests \( -name '*.sh' -o -name '*.pl' \) -exec chmod ugo+x {} \;

--- a/Makefile
+++ b/Makefile
@@ -180,14 +180,20 @@ uninstall:
 		$(call echocmd,"  UNINST  $(SCRIPT_INST_DIR)/$$s")  \
 		$(RM) -f $(SCRIPT_INST_DIR)/$$s ; \
 	done
-	rmdir --ignore-fail-on-non-empty $(SCRIPT_INST_DIR)
+	rmdir --ignore-fail-on-non-empty $(SCRIPT_INST_DIR) || true
 	for l in $(LIBS) ; do \
 		$(call echocmd,"  UNINST  $(LIB_INST_DIR)/$$l") \
 		$(RM) -f $(LIB_INST_DIR)/$$l ; \
 	done
 	rmdir --ignore-fail-on-non-empty $(LIB_INST_DIR) || true
-	rmdir `dirname $(LIB_INST_DIR)` || true
-	rm -rf `dirname $(SHARE_INST_DIR)`
+	for m in $(MANPAGES) ; do \
+		$(call echocmd,"  UNINST  $(MAN_INST_DIR)/$$m") \
+		$(RM) -f $(MAN_INST_DIR)/$$m ; \
+	done
+	rmdir --ignore-fail-on-non-empty $(MAN_INST_DIR)/man5 || true
+	rmdir --ignore-fail-on-non-empty $(MAN_INST_DIR)/man1 || true
+	rmdir --ignore-fail-on-non-empty $(MAN_INST_DIR) || true
+	$(RM) -rf $(SHARE_INST_DIR)
 	$(call echocmd,"  UNINST  $(CFG_INST_DIR)/lcovrc")
 	$(RM) -f $(CFG_INST_DIR)/lcovrc
 	rmdir --ignore-fail-on-non-empty $(CFG_INST_DIR) || true

--- a/Makefile
+++ b/Makefile
@@ -157,13 +157,6 @@ install:
 		done ;  \
 	done
 	mkdir -p $(SHARE_INST_DIR)
-	for d in example tests ; do \
-		( cd $$d ; make clean ) ; \
-		find $$d -type d -exec mkdir -p "$(SHARE_INST_DIR)/{}" \; ; \
-		find $$d -type f -exec $(INSTALL) -Dm 644 "{}" "$(SHARE_INST_DIR)/{}" \; ; \
-	done ;
-	@chmod -R ugo+x $(SHARE_INST_DIR)/tests/bin
-	@find $(SHARE_INST_DIR)/tests \( -name '*.sh' -o -name '*.pl' \) -exec chmod ugo+x {} \;
 	$(INSTALL) -d -m 755 $(CFG_INST_DIR)
 	$(call echocmd,"  INSTALL $(CFG_INST_DIR)/lcovrc")
 	$(INSTALL) -m 644 lcovrc $(CFG_INST_DIR)/lcovrc
@@ -193,7 +186,7 @@ uninstall:
 	rmdir --ignore-fail-on-non-empty $(MAN_INST_DIR)/man5 || true
 	rmdir --ignore-fail-on-non-empty $(MAN_INST_DIR)/man1 || true
 	rmdir --ignore-fail-on-non-empty $(MAN_INST_DIR) || true
-	$(RM) -rf $(SHARE_INST_DIR)
+	rmdir --ignore-fail-on-non-empty $(SHARE_INST_DIR) || true
 	$(call echocmd,"  UNINST  $(CFG_INST_DIR)/lcovrc")
 	$(RM) -f $(CFG_INST_DIR)/lcovrc
 	rmdir --ignore-fail-on-non-empty $(CFG_INST_DIR) || true


### PR DESCRIPTION
lcov's `make uninstall` wiped my `~/.local/share`. This was... surprising.

The offending line is https://github.com/linux-test-project/lcov/blob/b1a533238dbf6a8a603a44c6ec46b2cbb57086a0/Makefile#L190

`SHARE_DIR_INST` comes from:
```makefile
SHARE_DIR := $(PREFIX)/share/lcov/
SHARE_INST_DIR := $(DESTDIR)$(SHARE_DIR)
```

So, `make uninstall PREFIX=${HOME}/.local` would give us:
```shell
rm -rf `dirname /home/nega/.local/share/lcov`
```

and, since `dirname` gives us the "last non-slash component and trailing slashes removed" we're just doing
```shell
rm -rf /home/nega/.local/share`
```

On the Good/Bad Scale, this ranks as a "Bad". I'm glad I didn't use the default `PREFIX` of `/usr/local`. Losing `/usr/local/share` would have been more than an "inconvenience".

This PR removes this gross hammer, by removing the examples and tests from the `make install` target. It also cleans up the manpages that `make uninstall` ignores.

Ideally, the `uninstall` target would be removed outright until a less fragile version is developed.

Signed-off-by: nega <nega0@users.noreply.github.com>

---

* prefer to be explicit when constructing paths
* fix aggressive "rm -rf" with a less aggressive "rm -rf"
* remove examples and tests from the install target