### PR TITLE
Remove the "uninstall" target from the Makefile

### DIFF
--- a/.github/workflows/run_test_suite.yml
+++ b/.github/workflows/run_test_suite.yml
@@ -111,13 +111,6 @@ jobs:
           make install PREFIX=/usr CFG_DIR=/etc DESTDIR="${PWD}/ROOT"
           find ROOT/ | sort | xargs -r ls -ld
 
-      - name: make uninstall
-        run: |-
-          set -x -o pipefail
-          make uninstall PREFIX=/usr CFG_DIR=/etc DESTDIR="${PWD}/ROOT"
-          find ROOT/ | sort | xargs -r ls -ld
-          diff -u0 <(echo 'total 0') <(ls -l ROOT/)  # i.e. fail CI if leftovers
-
       - name: make check
         run: |-
           set -x -o pipefail

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@
 #
 # Make targets:
 #   - install:   install LCOV tools and man pages on the system
-#   - uninstall: remove tools and man pages from the system
 #   - dist:      create files required for distribution, i.e. the lcov.tar.gz
 #                and the lcov.rpm file. Just make sure to adjust the VERSION
 #                and RELEASE variables below - both version and date strings
@@ -93,14 +92,13 @@ else
 .SILENT:
 endif
 
-.PHONY: all info clean install uninstall rpms test
+.PHONY: all info clean install rpms test
 
 all: info
 
 info:
 	@echo "Available make targets:"
 	@echo "  install   : install binaries and man pages in DESTDIR (default /)"
-	@echo "  uninstall : delete binaries and man pages from DESTDIR (default /)"
 	@echo "  dist      : create packages (RPM, tarball) ready for distribution"
 	@echo "  check     : perform self-tests"
 	@echo "  checkstyle: check source files for coding style issues"
@@ -168,30 +166,6 @@ install:
 	$(call echocmd,"  INSTALL $(CFG_INST_DIR)/lcovrc")
 	$(INSTALL) -m 644 lcovrc $(CFG_INST_DIR)/lcovrc
 	$(call echocmd,"  done INSTALL")
-
-
-uninstall:
-	for b in $(EXES) ; do \
-		$(call echocmd,"  UNINST  $(BIN_INST_DIR)/$$b") \
-		$(RM) -f $(BIN_INST_DIR)/$$b ; \
-	done
-	rmdir --ignore-fail-on-non-empty $(BIN_INST_DIR) || true
-	for s in $(SCRIPTS) ; do \
-		$(call echocmd,"  UNINST  $(SCRIPT_INST_DIR)/$$s")  \
-		$(RM) -f $(SCRIPT_INST_DIR)/$$s ; \
-	done
-	rmdir --ignore-fail-on-non-empty $(SCRIPT_INST_DIR)
-	for l in $(LIBS) ; do \
-		$(call echocmd,"  UNINST  $(LIB_INST_DIR)/$$l") \
-		$(RM) -f $(LIB_INST_DIR)/$$l ; \
-	done
-	rmdir --ignore-fail-on-non-empty $(LIB_INST_DIR) || true
-	rmdir `dirname $(LIB_INST_DIR)` || true
-	rm -rf `dirname $(SHARE_INST_DIR)`
-	$(call echocmd,"  UNINST  $(CFG_INST_DIR)/lcovrc")
-	$(RM) -f $(CFG_INST_DIR)/lcovrc
-	rmdir --ignore-fail-on-non-empty $(CFG_INST_DIR) || true
-	rmdir --ignore-fail-on-non-empty $(DESTDIR)$(PREFIX) || true
 
 dist: lcov-$(VERSION).tar.gz lcov-$(VERSION)-$(RELEASE).noarch.rpm \
       lcov-$(VERSION)-$(RELEASE).src.rpm

--- a/README
+++ b/README
@@ -73,7 +73,7 @@ Further README contents
   man                - Directory containing man pages for included tools
   example            - Directory containing an example to demonstrate LCOV
   tests              - Directory containing lcov regression tests
-  Makefile           - Makefile providing 'install' and 'uninstall' targets
+  Makefile           - Makefile providing 'install', 'check' and other targets
 
 
 2. Installing LCOV


### PR DESCRIPTION
The "uninstall" target is dangerous as it tries to remove more than what the "install" installs. Also removes the relevant CI workflow step and reference in the README. Preferred to #389.