### PR TITLE
Start covering GCC 15 in CI

### DIFF
--- a/.github/workflows/run_test_suite.yml
+++ b/.github/workflows/run_test_suite.yml
@@ -47,8 +47,20 @@ jobs:
           - runs-on: ubuntu-24.04
             gcc: 14
             install:
+          - runs-on: ubuntu-24.04
+            gcc: 15
+            install: binutils g++-15 gcc-15 cpp-15
     steps:
       - uses: actions/checkout@v4
+
+      - name: Add repository "ubuntu-toolchain-r" for GCC 15
+        if: "${{ matrix.gcc == '15' }}"
+        run: |
+          set -x
+          # The repository is at home at https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test .
+          # NOTE: plucky is 25.04 (not 24.04 LTS)
+          wget -O - 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xc8ec952e2a0e1fbdc5090f6a2c277a0a352154e5' | sudo apt-key add -
+          sudo add-apt-repository 'deb https://ppa.launchpadcontent.net/ubuntu-toolchain-r/test/ubuntu plucky main'
 
       - name: Install dependencies
         run: |-


### PR DESCRIPTION
@henry2cox I keep getting this mismatch error:

```
+ make check
Creating coverage files (2 tests, 5 source files)
  Source tree ......... done (950 lines, 50 functions, 3428 branches)
  Full coverage ....... done
  Target coverage ..... done
  Partial coverage .... done
  Zero coverage ....... done
Starting tests
genhtml/full.sh ................... [pass] (time 0.5s, mem 47.0MB)
genhtml/zero.sh ................... [pass] (time 0.5s, mem 46.8MB)
genhtml/demangle.sh ............... [pass] (time 1.4s, mem 39.0MB)
genhtml/relative/relative.sh ...... [pass] (time 0.3s, mem 39.0MB)
genhtml/lambda/lambda.sh .......... [fail] (time 1.5s, mem 124.2MB)
    Skipping 165 previous lines (see /home/runner/work/lcov-fork/lcov-fork/tests//test.log)
    ...
      Lines executed:94.21% of 916
    stderr:
      /home/runner/work/lcov-fork/lcov-fork/tests/genhtml/lambda/lambda.gcno:version 'B33*', prefer 'B50 '
      /home/runner/work/lcov-fork/lcov-fork/tests/genhtml/lambda/lambda.gcda:version 'B33*', prefer version 'B50 '
    lcov: ERROR: (version) Incompatible GCC/GCOV version found while processing /home/runner/work/lcov-fork/lcov-fork/tests/genhtml/lambda/lambda.gcda:
    	Your test was built with 'B33*'.
    	You are trying to capture with gcov tool '/usr/bin/gcov' which is version 'B50 '.
    	(use "lcov --ignore-errors version ..." to bypass this error)
    Error:  unexpected error code from lcov
  EXITCODE ...: 1
make[3]: *** [../../common.mak:116: check] Error 1
make[2]: *** [../common.mak:116: check] Error 1
5 tests executed, 4 passed, 1 failed, 0 skipped (time 4.2s, mem 296.0MB)
Result log stored in /home/runner/work/lcov-fork/lcov-fork/tests/test.log
make[1]: *** [common.mak:116: check] Error 1
make: *** [Makefile:270: check] Error 2
```

Both GCC and GCOV are at version 15 here so I'm not sure why. Does "B33" and "B50" ring a bell with you? Any ideas what to try?