### PR TITLE
DOCUMENTATION:  note that the .info file format is described in the 'geninfo' man page.

### DIFF
--- a/man/genhtml.1
+++ b/man/genhtml.1
@@ -227,6 +227,9 @@ and
 .B lcov
 tools which are found from glob-match pattern(s)
 .I tracefile_pattern.
+See man
+.B geninfo(1) for a description of the tracefile format.
+
  Features include:
 
 .IP \(bu 3

--- a/man/lcov.1
+++ b/man/lcov.1
@@ -6,7 +6,13 @@
 lcov \- a graphical GCOV front\-end
 .SH SYNOPSIS
 
-Capture coverage data tracefile (from compiler-generated data):
+Capture coverage data tracefile (from compiler-generated data).
+.br
+The lcov tracefile
+.I (".info" file)
+format is described in man
+.B geninfo(1).
+
 .br
 
 .RS 3


### PR DESCRIPTION
Signed-off-by:  Henry Cox <henry.cox@mediatek.com>