### PR TITLE
'genhtml --simplfy-script callback ..' feature.

### DIFF
--- a/README
+++ b/README
@@ -371,7 +371,7 @@ LCOV features and capabilities fall into 7 major categories:
           --baseline-title, --baseline-date, --current-date,
           --flat, --hierarchical,
           --show-owners, --show-noncode, --show-navigation, --show-proportion,
-          --suppress-aliases
+          --suppress-aliases --simplify-script
 
   d) Data manipulation
 
@@ -421,8 +421,10 @@ LCOV features and capabilities fall into 7 major categories:
            the changes caused by a particular commit or range of commits,
            or to review changes in a particular release.
            Sample script:  select.pm
-         vi) keep track of environment and other settings - to aid
+        vi) keep track of environment and other settings - to aid
             infrastructure debugging in more complicated use cases.
+        vii) compress the 'function detail' table to improve readability
+             by shortening long C++ template and function names.
 
      The callback may be any desired script or executable - but there
      may be performance advantages if it is written as a Perl module.
@@ -436,6 +438,7 @@ LCOV features and capabilities fall into 7 major categories:
      Related options:
        --annotate-script, --criteria-script, --version-script
        --resolve-script, --select-script, --context-script
+       --simplify-script
 
   f) Performance
 

--- a/bin/genhtml
+++ b/bin/genhtml
@@ -291,6 +291,8 @@ sub write_overview(*$$$$);
 # External prototype (defined in genpng)
 sub gen_png($$$$$@);
 
+sub simplify_function_name($);
+
 package SummaryInfo;
 
 our @selectCallbackScript;
@@ -5471,7 +5473,7 @@ sub _computeAge
     if ($then > $now) {
         if (lcovutil::warn_once($lcovutil::ERROR_INCONSISTENT_DATA, $path)) {
             # issue annotation warning at most once per file
-	    # also attempt to clarify where the date comes from
+            # also attempt to clarify where the date comes from
             my $data =
                 exists($ENV{SOURCE_DATE_EPOCH}) ?
                 (
@@ -6853,10 +6855,14 @@ our @rate_png     = ("ruby.png", "amber.png", "emerald.png");
 our $rc_desc_html = 0;      # lcovrc: genhtml_desc_html
 our $deprecated_highlight;    # ignored former option
 
-our $cwd = cwd();             # Current working directory
+# simplify/shorten names in 'function detail table'
+our @simplifyFunctionScript;      # the arg list
+our $simplifyFunctionCallback;    # the actual callback
+
+our $cwd = cwd();                 # Current working directory
 
 # for debugging
-our $verboseScopeRegexp;      # dump categorization processing if match
+our $verboseScopeRegexp;          # dump categorization processing if match
 
 #
 # Code entry point
@@ -6869,7 +6875,8 @@ STDERR->autoflush;
 STDOUT->autoflush;
 
 my @datebins;
-my (@rc_date_bins, @rc_annotate_script, @rc_select_script, @rc_date_labels);
+my (@rc_date_bins, @rc_annotate_script, @rc_select_script, @rc_date_labels,
+    @rc_simplifyFunctionScript);
 
 my %genhtml_rc_opts = (
                "genhtml_css_file"            => \$css_filename,
@@ -6925,6 +6932,7 @@ my %genhtml_rc_opts = (
                'genhtml_annotate_script'     => \@rc_annotate_script,
                'genhtml_annotate_tooltip'    => \$SourceFile::annotateTooltip,
                "select_script"               => \@rc_select_script,
+               "simplify_function"           => \@rc_simplifyFunctionScript,
                'num_context_lines' => \$InInterestingRegion::num_context_lines,
                'genhtml_date_bins' => \@rc_date_bins,
                'genhtml_date_labels'        => \@rc_date_labels,
@@ -6938,60 +6946,62 @@ my $save;
 my $serialize;
 my $validateHTML = exists($ENV{LCOV_VALIDATE});
 
-my %genhtml_options = ("output-directory|o=s" => \$output_directory,
-                       "header-title=s"       => \$header_title,
-                       "footer=s"             => \$footer,
-                       "title|t=s"            => \$test_title,
-                       "description-file|d=s" => \$desc_filename,
-                       "keep-descriptions|k"  => \$keep_descriptions,
-                       "css-file|c=s"         => \$css_filename,
-                       "baseline-file|b=s"    => \@base_filenames,
-                       "baseline-title=s"     => \$baseline_title,
-                       "baseline-date=s"      => \$baseline_date,
-                       "current-date=s"       => \$current_date,
-                       "diff-file=s"          => \$diff_filename,
-                       "annotate-script=s"    => \@SourceFile::annotateScript,
-                       "select-script=s"      => \@selectCallbackScript,
-                       "new-file-as-baseline" => \$treatNewFileAsBaseline,
-                       'elide-path-mismatch'  => \$elide_path_mismatch,
-                       'synthesize-missing'   => \$synthesizeMissingFile,
-                       # if 'show-owners' is set: generate the owner table
-                       #    if it is passed a value: show all the owners,
-                       #    regardless of whether they have uncovered code or not
-                       'show-owners:s'     => \$show_ownerBins,
-                       'show-noncode'      => \$show_nonCodeOwners,
-                       'show-zero-columns' => \$show_zeroTlaColumns,
-                       'simplified-colors' => \$show_simplifiedColors,
-                       "date-bins=s"       => \@datebins,
-                       'date-labels=s'     => \@SummaryInfo::ageGroupHeader,
-                       "prefix|p=s"        => \@opt_dir_prefix,
-                       "num-spaces=i"      => \$tab_size,
-                       "no-prefix"         => \$no_prefix,
-                       "no-sourceview"     => \$no_sourceview,
-                       'no-html'           => \$no_html,
-                       "show-details|s"    => \$show_details,
-                       "frames|f"          => \$frames,
-                       "highlight"         => \$deprecated_highlight,
-                       "legend"            => \$legend,
-                       'save'              => \$save,
-                       'serialize=s'       => \$serialize,
-                       'scheduler+'        => \$debugScheduler,
-                       "html-prolog=s"     => \$html_prolog_file,
-                       "html-epilog=s"     => \$html_epilog_file,
-                       "html-extension=s"  => \$html_ext,
-                       "html-gzip"         => \$html_gzip,
-                       "hierarchical"      => \$hierarchical,
-                       "flat"              => \$flat,
-                       "sort-tables"       => \$sort_tables,
-                       "no-sort"           => \$no_sort,
-                       "precision=i"       => \$lcovutil::default_precision,
-                       "missed"            => \$opt_missed,
-                       "dark-mode"         => \$dark_mode,
-                       "show-navigation"   => \$show_tla,
-                       "show-proportion"   => \$show_functionProportions,
-                       "merge-aliases"     => \$merge_function_aliases,
-                       "suppress-aliases"  => \$suppress_function_aliases,
-                       'validate'          => \$validateHTML,);
+my %genhtml_options = (
+                     "output-directory|o=s" => \$output_directory,
+                     "header-title=s"       => \$header_title,
+                     "footer=s"             => \$footer,
+                     "title|t=s"            => \$test_title,
+                     "description-file|d=s" => \$desc_filename,
+                     "keep-descriptions|k"  => \$keep_descriptions,
+                     "css-file|c=s"         => \$css_filename,
+                     "baseline-file|b=s"    => \@base_filenames,
+                     "baseline-title=s"     => \$baseline_title,
+                     "baseline-date=s"      => \$baseline_date,
+                     "current-date=s"       => \$current_date,
+                     "diff-file=s"          => \$diff_filename,
+                     "annotate-script=s"    => \@SourceFile::annotateScript,
+                     "select-script=s"   => \@SummaryInfo::selectCallbackScript,
+                     "simplify-script=s" => \@simplifyFunctionScript,
+                     "new-file-as-baseline" => \$treatNewFileAsBaseline,
+                     'elide-path-mismatch'  => \$elide_path_mismatch,
+                     'synthesize-missing'   => \$synthesizeMissingFile,
+                     # if 'show-owners' is set: generate the owner table
+                     #    if it is passed a value: show all the owners,
+                     #    regardless of whether they have uncovered code or not
+                     'show-owners:s'     => \$show_ownerBins,
+                     'show-noncode'      => \$show_nonCodeOwners,
+                     'show-zero-columns' => \$show_zeroTlaColumns,
+                     'simplified-colors' => \$show_simplifiedColors,
+                     "date-bins=s"       => \@datebins,
+                     'date-labels=s'     => \@SummaryInfo::ageGroupHeader,
+                     "prefix|p=s"        => \@opt_dir_prefix,
+                     "num-spaces=i"      => \$tab_size,
+                     "no-prefix"         => \$no_prefix,
+                     "no-sourceview"     => \$no_sourceview,
+                     'no-html'           => \$no_html,
+                     "show-details|s"    => \$show_details,
+                     "frames|f"          => \$frames,
+                     "highlight"         => \$deprecated_highlight,
+                     "legend"            => \$legend,
+                     'save'              => \$save,
+                     'serialize=s'       => \$serialize,
+                     'scheduler+'        => \$debugScheduler,
+                     "html-prolog=s"     => \$html_prolog_file,
+                     "html-epilog=s"     => \$html_epilog_file,
+                     "html-extension=s"  => \$html_ext,
+                     "html-gzip"         => \$html_gzip,
+                     "hierarchical"      => \$hierarchical,
+                     "flat"              => \$flat,
+                     "sort-tables"       => \$sort_tables,
+                     "no-sort"           => \$no_sort,
+                     "precision=i"       => \$lcovutil::default_precision,
+                     "missed"            => \$opt_missed,
+                     "dark-mode"         => \$dark_mode,
+                     "show-navigation"   => \$show_tla,
+                     "show-proportion"   => \$show_functionProportions,
+                     "merge-aliases"     => \$merge_function_aliases,
+                     "suppress-aliases"  => \$suppress_function_aliases,
+                     'validate'          => \$validateHTML,);
 
 # remove ambiguous entry from common table -
 #   (genhtml has '--sort-inputs' and '--sort-tables')
@@ -7041,17 +7051,27 @@ $frames         = undef unless (defined($frames) && $frames);
 foreach my $rc ([\@datebins, \@rc_date_bins],
                 [\@SummaryInfo::ageGroupHeader, \@rc_date_labels],
                 [\@SourceFile::annotateScript, \@rc_annotate_script],
-                [\@selectCallbackScript, \@rc_select_script]
+                [\@SummaryInfo::selectCallbackScript, \@rc_select_script],
+                [\@simplifyFunctionScript, \@rc_simplifyFunctionScript],
 
 ) {
     @{$rc->[0]} = @{$rc->[1]} unless (@{$rc->[0]});
 }
 
 foreach my $cb ([\$SourceFile::annotateCallback, \@SourceFile::annotateScript],
-                [\$selectCallback, \@selectCallbackScript]) {
+                [\$SummaryInfo::selectCallback,
+                 \@SummaryInfo::selectCallbackScript
+                ],
+                [\$simplifyFunctionCallback, \@simplifyFunctionScript],
+) {
     lcovutil::configure_callback($cb->[0], @{$cb->[1]})
         if scalar(@{$cb->[1]});
 }
+
+# we won't apply simplifications if we don't generate the table
+#  (we still check that the callback is valid - even though we don't use it)
+$simplifyFunctionCallback = undef
+    if $no_sourceview;
 
 if (defined($lcovutil::stop_on_error) &&
     !$lcovutil::stop_on_error) {
@@ -8384,7 +8404,7 @@ sub read_testfile($)
     local *TEST_HANDLE;
 
     open(TEST_HANDLE, "<", $file) or
-        die("cannot open $file]: $!\n");
+        die("cannot open description file '$file': $!\n");
 
     while (<TEST_HANDLE>) {
         chomp($_);
@@ -13322,7 +13342,7 @@ sub write_source($$$$$$$$)
     my $cbdata      = PrintCallback->new($srcfile, $fileCovInfo);
 
     my ($region, $empty);
-    if ($selectCallback) {
+    if ($SummaryInfo::selectCallback) {
         $region = InInterestingRegion->new($srcfile, $fileCovInfo->lineMap());
         $empty  = '';
         if ($srcfile->isProjectFile()) {
@@ -13583,7 +13603,7 @@ END_OF_HTML
         next
             if grep(/^$tla$/, ('DUB', 'DCB')); # don't display deleted functions
         my $startline = $funcEntry->line() - $func_offset;
-        my $name      = $func;
+        my $name      = simplify_function_name($func);
         my $countstyle;
 
         # Escape special characters
@@ -13701,7 +13721,7 @@ END_OF_HTML
                 }
 
                 # Escape special characters
-                $alias = escape_html($alias);
+                $alias = escape_html(simplify_function_name($alias));
 
                 write_html(*HTML_HANDLE, <<END_OF_HTML);
             <tr>
@@ -13877,4 +13897,25 @@ sub parse_dir_prefix(@)
             push(@dir_prefix, $item);
         }
     }
+}
+
+#
+# simplify_function_name($name)
+#
+# apply @function_simplify_patterns to $name and return
+#  goal is to shorten really long demangled names/template expansions
+#
+sub simplify_function_name($)
+{
+    my $name = shift;
+    if ($simplifyFunctionCallback) {
+
+        eval { $name = $simplifyFunctionCallback->simplify($name); };
+        if ($@) {
+            my $context = MessageContext::context();
+            lcovutil::ignorable_error($lcovutil::ERROR_CALLBACK,
+                                      "simplify($name) failed$context: $@");
+        }
+    }
+    return $name;
 }

--- a/bin/llvm2lcov
+++ b/bin/llvm2lcov
@@ -239,7 +239,8 @@ sub parse
                 }
                 if ($mcdc && $json_version < version->parse("3.0.1")) {
                     my $mcdcData = $fileInfo->testcase_mcdc($testname);
-                    my @mcdcBranches;       # array (start line, start column, expression)
+                    my @mcdcBranches
+                        ;    # array (start line, start column, expression)
                     foreach my $branch (@$branches) {
                         die("unexpected branch data")
                             unless scalar(@$branch) == 9;
@@ -273,8 +274,8 @@ sub parse
                             if (($brLine > $line ||
                                  ($brLine == $line && $brCol >= $startCol))
                                 &&
-                                ($brLine < $endLine ||
-                                 ($brLine == $endLine && $brCol <= $endCol))
+                                (   $brLine < $endLine ||
+                                    ($brLine == $endLine && $brCol <= $endCol))
                             ) {
                                 push(@brExprs, [$brLine, $brCol, $brExpr]);
                             }
@@ -344,8 +345,10 @@ sub parse
                     $functionMap->add_count($name, $count);
                 }
 
-                my @mcdcBranches;           # array (fileId, start line, start column, expression)
-                my %expanded_mcdcBranches;  # hash of branch's fileId -> branch's start line
+                my @mcdcBranches
+                    ;    # array (fileId, start line, start column, expression)
+                my %expanded_mcdcBranches
+                    ;    # hash of branch's fileId -> branch's start line
 
                 if ($branchData) {
                     my $funcBranchData = BranchData->new();
@@ -451,15 +454,17 @@ sub parse
                                 if (($brLine > $line ||
                                      ($brLine == $line && $brCol >= $col))
                                     &&
-                                    ($brLine < $endLine ||
-                                     ($brLine == $endLine && $brCol <= $endCol))
+                                    (   $brLine < $endLine ||
+                                        ($brLine == $endLine &&
+                                            $brCol <= $endCol))
                                 ) {
                                     push(@brExprs, [$brLine, $brCol, $brExpr]);
                                 }
                             }
-                            @brExprs = sort {$a->[0] <=> $b->[0] ||
-                                             $a->[1] <=> $b->[1]
-                                            } @brExprs;
+                            @brExprs = sort {
+                                $a->[0]     <=> $b->[0] ||
+                                    $a->[1] <=> $b->[1]
+                            } @brExprs;
                             $expr =
                                 $srcReader->getExpr($line, $col,
                                                     $endLine, $endCol)

--- a/man/genhtml.1
+++ b/man/genhtml.1
@@ -146,6 +146,9 @@ genhtml \- Generate HTML view from LCOV coverage data files
 .RB [ \-\-select\-script
 .IR script  ]
 .br
+.RB [ \-\-simplify\-script
+.IR script ]
+.br
 .RB [ \-\-checksum ]
 .br
 .RB [ \-\-fail\-under\-branches
@@ -432,6 +435,8 @@ following options:
 .br
 .B \-\-select\-script
 .br
+.B \-\-simplify\-script
+.br
 .B \-\-version\-script
 .br
 .RE
@@ -602,6 +607,23 @@ where
 is the correct path to the indicated source file or
 .I undef
 if the source file is not found by the callback.
+.PP
+
+.IP simplify\-script
+$new_func_name = $callback_obj->simplify($orig_func_name)
+.br
+.br
+
+where
+.I $new_func_name
+is the function name which will appear in the function detail table and
+.I $orig_func_name
+is the (possibly demangled) function name found in the coverage DB.
+
+.br
+Note that the modified name is only used in the "function detail" table
+and does not modify information in the coveage DB.
+
 .PP
 
 .RE
@@ -1818,6 +1840,28 @@ config file option. See man
 for details.
 .RE
 
+.B \-\-simplify\-script
+.I callback
+.br
+.RS
+Use
+.I callback
+to shorten/simplify long demangled C++ function and template names to make the function detail table more compact and readable - for example, to
+remove nested namespace names.
+
+Note that the simplifications affect only the display and not the actual names
+stored in the coverage DB.  In particular, the DB name (not the simplified name)
+is the one used to match
+.I \-\-erase\-function
+patterns.
+
+This option is equivalent to the
+.B simplify_script
+config file option. See man
+.B lcovrc(5)
+for details
+.RE
+
 .BI "\-\-checksum "
 .RS
 Specify whether to compare stored tracefile checksum to checksum computed from the source code.
@@ -2127,9 +2171,8 @@ Note that this option requires that you use a compiler version which is new enou
 .BI derive_function_end_line
 discussion in man
 .B lcovrc(5).
-
-
 .RE
+
 .B \-\-substitute
 .I regexp_pattern
 .br
@@ -3538,6 +3581,22 @@ feature can instead be realized by
 .I "genhtml --criteria-script \*[scriptdir]/threshold.pm,--line,75 ..."
 .RE
 .br
+.RE
+.RE
+
+Sample
+.I \-\-simplify\-script
+callback Perl module:
+.RS
+
+.I \*[scriptdir]/simplify.pm
+.RS
+Sample script written as Perl module for use with
+.B \-\-simplify\-script
+that implements regular expression substitutions for function name simplification.
+.br
+.RE
+
 .RE
 .RE
 

--- a/man/lcovrc.5
+++ b/man/lcovrc.5
@@ -3154,6 +3154,21 @@ This option is used by genhtml, lcov, and geninfo.
 
 .PP
 
+.BR simplify_script " ="
+.IR path_to_executable | parameter
+.IP
+
+This option is equivalent to the genhtml
+.I \-\-simplify\-script
+ option. 
+This option can be used multiple times in the lcovrc file to specify both a simplify script and additional options which are passed to the script.
+
+See man
+.B genhtml(1)
+for details.
+
+.PP
+
 .BR substitute " ="
 .IR regexp
 .IP
@@ -3162,7 +3177,8 @@ This option is equivalent to the \-\-substitute option to geninfo, lcov, and gen
 See the lcov man page for details.;
 
 This option can be used multiple times in the lcovrc file to specify multiple substitution patterns.
-The patterns specified in the lcovrc file are appended to the list specified on the command line.
+If patterns are specified on both the command line and in the lcovrc file, then
+the command line patterns are used and the lcovrc patterns are dropped.
 
 .br
 This option is used by genhtml, lcov, and geninfo.

--- a/scripts/simplify.pm
+++ b/scripts/simplify.pm
@@ -1,0 +1,114 @@
+#!/usr/bin/end perl
+
+#   Copyright (c) MediaTek USA Inc., 2025
+#
+#   This program is free software;  you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or (at
+#   your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY;  without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program;  if not, see
+#   <http://www.gnu.org/licenses/>.
+#
+#
+# simplify.pm [--file pattern_file] [--re regexp] [--separator sep_char]
+#
+#   This is a sample 'genhtml --simplify-script' callback - used to decide
+#   whether shorten the (possibly demangled) function names displayed in the
+#   'function detail' tables.
+#   Note that the simplified names are ONLY used in the table - the
+#   coverage DB is not affected - so, for example '--erase-function'
+#   regexps must match the actual (possibly demangled) name of the function.
+#
+#   --file: is the name of a file containing Perl regexpe, one per line
+#
+#   --re:  is a perl regexp or 'sep_char' separated list of regexps.
+#
+#   --separator: is the character used to separate the list of regexpe.
+#               (',' is probably a poor choice as perl regexps often contain
+#               comma.
+
+package simplify;
+
+use strict;
+use Getopt::Long qw(GetOptionsFromArray);
+use File::Basename qw(dirname basename);
+use lcovutil;
+
+our @ISA       = qw(Exporter);
+our @EXPORT_OK = qw(new);
+
+sub new
+{
+    my $class  = shift;
+    my $script = shift;
+    my (@patterns, $file, $sep);
+    my @args       = @_;
+    my $exe        = basename($script ? $script : $0);
+    my $standalone = $script eq $0;
+    my $help;
+    if (!GetOptionsFromArray(\@_,
+                             ("file:s"      => \$file,
+                              'separator:s' => \$sep,
+                              're:s'        => \@patterns,
+                              'help'        => \$help)) ||
+        $help                             ||
+        (!$standalone && 0 != scalar(@_)) ||
+        0 == scalar(@args)                ||    # expect at least one pattern
+        (@patterns && $file)              || !(@patterns || $file)
+    ) {
+        print(STDERR <<EOF);
+usage: $exe
+       [--file regexp_file_name]
+       OR
+       [--re regexp]*
+       [--separator separator_char]
+
+Regexps are applied in order of specificication.
+EOF
+
+        exit($help && 0 == scalar(@_) ? 0 : 1) if $standalone;
+        return undef;
+    }
+
+    if ($file) {
+        open(HANDLE, "<", $file) or
+            die("cannot open pattern file $file: $!\n");
+        while (<HANDLE>) {
+            chomp;
+            next if /^#/ || !$_;    # skip comment and blank
+            push(@patterns, $_);
+        }
+        close(HANDLE) or die("unable to close pattern file handle: $!\n");
+    } elsif (defined($sep)) {
+        @patterns = split($sep, join($sep, @patterns));
+    }
+
+    # verify that the patterns are valid...
+    lcovutil::verify_regexp_patterns($script, \@patterns);
+
+    return bless \@patterns, $class;
+}
+
+sub simplify
+{
+    my ($self, $name) = @_;
+
+    foreach my $p (@$self) {
+        # sadly, no support for pre-compiled patterns
+        eval "\$name =~ $p ;";    # apply pattern that user provided...
+            # $@ should never match:  we already checked pattern validity during
+            #   initialization - above.  Still: belt and braces.
+        die("invalid 'simplify' regexp '$p->[0]': $@")
+            if ($@);
+    }
+    return $name;
+}
+
+1;

--- a/tests/gendiffcov/errs/genError.pm
+++ b/tests/gendiffcov/errs/genError.pm
@@ -47,4 +47,9 @@ sub check_criteria
     die("die in check_criteria");
 }
 
+sub simplify
+{
+    die("die in simplify");
+}
+
 1;

--- a/tests/lcov/demangle/simplify.cmd
+++ b/tests/lcov/demangle/simplify.cmd
@@ -1,0 +1,6 @@
+# test the 'simplify.pm --file ...' option
+
+s/Animal::Animal/subst1/
+s/Cat::Cat/subst2/
+s/subst2/subst3/
+

--- a/tests/lcov/demangle/simplify.pl
+++ b/tests/lcov/demangle/simplify.pl
@@ -1,0 +1,11 @@
+#!/usr/bin/env perl
+use strict;
+
+my $name = shift;
+$name =~ s/Animal::Animal/subst1/;
+$name =~ s/Cat::Cat/subst2/;
+$name =~ s/subst2/subst3/;
+
+print $name;
+exit 0;
+

--- a/tests/lcov/errs/errs.sh
+++ b/tests/lcov/errs/errs.sh
@@ -156,7 +156,7 @@ for f in exceptionBranch ; do
         fi
     fi
 
-    echo lcov $LCOV_OPTS -a ${f}1.info -a ${f}2.info --ignroe mismatch -o ${f}2.log
+    echo lcov $LCOV_OPTS -a ${f}1.info -a ${f}2.info --ignore mismatch -o ${f}2.log
     $COVER $LCOV_TOOL $LCOV_OPTS -a ${f}1.info -a ${f}2.info --ignore mismatch -o $f.log
 
     if [ 0 != ${PIPESTATUS[0]} ] ; then


### PR DESCRIPTION
Use callback to munge function names for display.
Goal is to compress the function detail table by, for example, shortening long template or namespace names - e.g., to replace (long) typenames with the typedef names used in your code.

Implemented as a callback rather than, for example, as a list of regexps because any project complicated enough to need simplification is complicated enough that the required regexps will be very, very complicated. A callback is easier and more flexible.
See the sample implementation in .../scripts/simplify.pl

This feature may go part of the way toward satisfying #164.  (Function names will not be collapsed into one entry - but the table entries can be arbitrarily simple.)