### PR TITLE
genhtml: Fix apply_prefix regex on Windows

### DIFF
--- a/bin/genhtml
+++ b/bin/genhtml
@@ -13806,7 +13806,7 @@ sub apply_prefix($@)
             return 'root';
         }
         if ($prefix ne "" &&
-            $filename =~ /^\Q$prefix\E$lcovutil::dirseparator(.*)$/) {
+            $filename =~ /^\Q$prefix$lcovutil::dirseparator\E(.*)$/) {
             return substr($filename, length($prefix) + 1);
         }
     }


### PR DESCRIPTION
Ensure that `$lcovutil::dirseparator`, which can be a backslash, is properly escaped in the regex. Fixes an error of the form:

```
genhtml: ERROR: Unmatched ) in regex; marked by <-- HERE in m/^C\:\\b\\absmfft5\\execroot\\_main\\_tmp\\841d8b670c55601362e55b1ef828d048\\workspace\(.*) <-- HERE $/
```