### PR TITLE
`run_test_suite.yml`: Upload test run artifacts despite failure

### DIFF
--- a/.github/workflows/run_test_suite.yml
+++ b/.github/workflows/run_test_suite.yml
@@ -131,6 +131,7 @@ jobs:
           make check
 
       - name: Upload test log as an artifact
+        if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
           name: "lcov-${{ github.sha }}-${{ runner.os }}-GCC-${{ matrix.gcc }}-test-log"  # .zip
@@ -138,6 +139,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload test directory shrapnel  as an artifact
+        if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
           name: "lcov-${{ github.sha }}-${{ runner.os }}-GCC-${{ matrix.gcc }}-shrapnel"  # .zip


### PR DESCRIPTION
In reaction to https://github.com/linux-test-project/lcov/pull/483#issuecomment-4769140332

Related: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-not-requiring-successful-dependent-jobs

CC @henry2cox 