### PR TITLE
`rpm_action.yml`: Name releases `v{version}` rather than `Release v{version}`

### DIFF
--- a/.github/workflows/rpm_action.yml
+++ b/.github/workflows/rpm_action.yml
@@ -50,7 +50,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.get_version.outputs.VERSION }}
-          name: Release ${{ steps.get_version.outputs.VERSION }}
+          name: ${{ steps.get_version.outputs.VERSION }}
           files: |
             *.noarch.rpm
             *.src.rpm


### PR DESCRIPTION
Related to #488

CC @henry2cox 