### PR TITLE
`rpm_action.yml`: Avoid "beta" in non-beta release artifact names

### DIFF
--- a/.github/workflows/rpm_action.yml
+++ b/.github/workflows/rpm_action.yml
@@ -32,7 +32,11 @@ jobs:
           sudo apt-get install -y rpm devscripts equivs python3-sphinx python3-sphinx-rtd-theme perl git
 
       - name: Build RPMs
-        run: make rpms
+        run: |
+          if [[ ${GITHUB_REF} == refs/tags/v* ]]; then
+            export RELEASE=0  # avoids "beta" in bin/get_version.sh
+          fi
+          make rpms
 
       - name: Get version
         id: get_version


### PR DESCRIPTION
Related to #488

CC @henry2cox
