### PR TITLE
`rpm_action.yml`: Run all but release creation every time

### DIFF
--- a/.github/workflows/rpm_action.yml
+++ b/.github/workflows/rpm_action.yml
@@ -2,13 +2,7 @@ name: Build RPMs
 
 on:
   push:
-    branches:
-      - master
-    tags:
-      - 'v*'
   pull_request:
-    branches:
-      - master
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Related to #488

This will make problems in all but the last step show earlier, and hence help with debugging and keeping the workflow healthy. The existing `if: startsWith(github.ref, 'refs/tags/v')` already guards release creation for non-tag and non-v-tag pushes.

CC @henry2cox
