### PR TITLE
`docs/Makefile`: Fix syntax for target "clean" (and mark as phony)

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -21,5 +21,5 @@ help:
 %: Makefile
 	@LCOV_BUILD_DATE=$(BUILD_DATE) LCOV_RELEASE=$(RELEASE) TOOL_NAME=$(TOOL_NAME) $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-clean::
+clean:
 	rm -rf __pycache__

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,7 +14,7 @@ BUILDDIR      = _build
 help:
 	@LCOV_BUILD_DATE=$(BUILD_DATE) LCOV_RELEASE=$(RELEASE) TOOL_NAME=$(TOOL_NAME) $(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+.PHONY: clean help Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).


### PR DESCRIPTION
Caught my eye in commit 0f8aa73b3ad1404052ae83df2516640f973a35ef

CC @henry2cox 