### PR TITLE
`tests/genhtml/errs/select.sh`: Fix shebang line

### DIFF
--- a/tests/genhtml/errs/select.sh
+++ b/tests/genhtml/errs/select.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 #echo "$@_" >> x.log
 exit 1


### PR DESCRIPTION
`/usr/bin/bash` is not [portable](https://stackoverflow.com/a/2846072) (e.g. does not exist on Gentoo).

CC @henry2cox 