### PR TITLE
scripts: Fix import of `gitblame.pm` and `p4annotate.pm` (related to #499)

### DIFF
--- a/scripts/gitblame
+++ b/scripts/gitblame
@@ -39,7 +39,7 @@
 use strict;
 use FindBin;
 use lib "$FindBin::RealBin";
-use gitblame qw(new);
+use gitblame;
 use annotateutil qw(call_annotate);
 
 if (-f $ARGV[-1] || 0 != index($ARGV[-1], '-')) {

--- a/scripts/p4annotate
+++ b/scripts/p4annotate
@@ -35,7 +35,7 @@
 use strict;
 use FindBin;
 use lib "$FindBin::RealBin";
-use p4annotate qw(new);
+use p4annotate;
 use annotateutil qw(call_annotate);
 
 if (-f $ARGV[-1] || 0 != index($ARGV[-1], '-')) {


### PR DESCRIPTION
Related to #499

The symptom was:

```console
# ./scripts/gitblame --help
Attempt to call undefined import method with arguments ("new") via package "gitblame" (Perhaps you forgot to load the package?) at ./scripts/gitblame line 42.
usage: gitblame [--p4] [--abbrev regexp]* [--cache dir] [--verify] [--log logfile] [domain] pathname
```

CC @henry2cox 