### PR TITLE
tests: Support `/include/g++-v14/` libstdc++ header location (related to #499)

### DIFF
--- a/tests/lcov/extract/extract.sh
+++ b/tests/lcov/extract/extract.sh
@@ -226,7 +226,7 @@ if [ 0 != $? ] ; then
 fi
 
 # exclude some un-covered standard includes
-EXCLUDE='--exclude */include/c++/* --ignore unused'
+EXCLUDE='--exclude */include/c++/* --exclude */include/g++-v* --ignore unused'
 
 # callback tests
 echo $COVER $CAPTURE . $LCOV_OPTS -o callback.info $FILTER $IGNORE --criteria $SCRIPT_DIR/threshold.pm,--line,90,--branch,65,--function,100 $EXCLUDE


### PR DESCRIPTION
Related to #499

- Debian: `/usr/x86_64-linux-gnu/include/c++/14/bits/basic_string.h`
- Gentoo: `/usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/basic_string.h`

CC @henry2cox 