### PR TITLE
`Makefile`: Stop passing *.pm directories to `bin/checkstyle.sh`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,7 +331,7 @@ else
 	@echo "Checking changes in source files for coding style issues (MODE=diff):"
 endif
 	@RC=0 ;                                                  \
-	CHECKFILES=`find bin lib scripts tests -path ./.git -prune -o \( \( -type f -exec grep -q '^#!.*perl' {} \; \) -o -name '*.pm' \) -not \( -name '*.tdy' -o -name '*.orig' -o -name '*~' \) -print `; \
+	CHECKFILES=`find bin lib scripts tests -path ./.git -prune -o \( \( -type f -exec grep -q '^#!.*perl' {} \; \) -o -name '*.pm' -type f \) -not \( -name '*.tdy' -o -name '*.orig' -o -name '*~' \) -print `; \
 	for FILE in $$CHECKFILES ; do                            \
 	  $(CHECKSTYLE) "$$FILE";                                \
 	  if [ 0 != $$? ] ; then                                 \


### PR DESCRIPTION
The situation after a test run is this in the file system:

```console
# find . -name \*.pm -type d
./tests/genhtml/simple/criteria.pm
./tests/genhtml/simple/criteria_signoff.pm
```

The result is `make checkstyle` failing like this:

```console
# make checkstyle
[..]
fatal: path 'tests/genhtml/simple/criteria.pm' exists on disk, but not in 'HEAD'
Error: No version of tests/genhtml/simple/criteria.pm found in git ref HEAD
saw mismatch for tests/genhtml/simple/criteria.pm
[..]
fatal: path 'tests/genhtml/simple/criteria_signoff.pm' exists on disk, but not in 'HEAD'
Error: No version of tests/genhtml/simple/criteria_signoff.pm found in git ref HEAD
saw mismatch for tests/genhtml/simple/criteria_signoff.pm
[..]
make: *** [Makefile:332: checkstyle] Error 1
```

Now these directories are no longer passed by mistake.

CC @henry2cox 