### PR TITLE
Don't unnecessarily truncate test name in regress log.

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -21,8 +21,10 @@ TESTS := genhtml scripts lcov llvm2lcov py2lcov perl2lcov xml2lcov
 #  report - but they might not have been generated, so we need to
 #  ignore the potential 'empty glob pattern' error message and a
 #  potential remote repo timestamp issue
-EXCLUDES = genError.pm filter.pl brokenCallback.pm MsgContext.pm \
-	 missingRestore.pm parallelFail.pm '*/tmp*'
+EXCLUDES =                                            \
+	genError.pm brokenCallback.pm MsgContext.pm   \
+	missingRestore.pm parallelFail.pm             \
+	filter.pl '*/tmp*' 'tests/*' scheduling
 EXCL_OPTS = $(foreach e, $(EXCLUDES), --exclude $(e))
 OMIT_OPTS = --omit-lines 'ERROR_INTERNAL' --omit-lines '\bdie\b'
 IGNORE_OPTS = --ignore unsupported,unused,inconsistent

--- a/tests/bin/runtests.py
+++ b/tests/bin/runtests.py
@@ -310,11 +310,12 @@ class TestRunner:
         if self.args.silent:
             return
         
-        name = result.name
-        if len(name) > 32:
-            name = '...' + name[-29:]
+        fieldWidth = 35
+        name = result.name + ' '
+        if len(name) >= fieldWidth:
+            name = '...' + name[-(fieldWidth-2):-1]
         
-        name_field = f"{name} {'.' * (35 - len(name))}"
+        name_field = f"{name}{'.' * (fieldWidth - len(name))}"
         
         if result.result == 'pass':
             color = GREEN


### PR DESCRIPTION
Clean up regress coverage report.