### PR TITLE
Add common "--ignore-whitespace/-b" option to annotate callbacks.

### DIFF
--- a/bin/perl2lcov
+++ b/bin/perl2lcov
@@ -157,7 +157,7 @@ lcovutil::set_extensions('perl', '.*');
 my $testname    = '';
 my $output_file = 'perlcov.info';
 our %options = ('test-name=s' => \$testname,
-                'output|o=s' => \$output_file,);
+                'output|o=s'  => \$output_file,);
 if (!lcovutil::parseOptions({}, \%options)) {
     print(STDERR "Use $lcovutil::tool_name --help to get usage information.\n");
     exit(1);

--- a/docs/man/genhtml.rst
+++ b/docs/man/genhtml.rst
@@ -658,6 +658,8 @@ In general, (almost) all ``genhtml`` options can also be specified in your perso
 
    Note that these scripts generate annotations from the file version checked in to the repository - not the locally modified file in the build directory. If you need annotations for locally modified files, you can shelve your changes in P4, or check them in to a local branch in git.
 
+   Both sample scripts accept a number of options - ``--cache``, ``--verify``, ``-b`` (or ``--ignore-whitespace``) and ``--log`` - which may be passed after the script name in the *script,args* form described in **Script conventions** above. See the **Callback Scripts** section of the |TOOL_NAME| documentation for details.
+
    **Creating your own script**
 
    When creating your own script, please first see **Script considerations** above for general calling conventions and script requirements.

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -53,7 +53,19 @@ annotation specification.
    Cache directory for storing previous results to improve performance.
 
 ``--verify``
-   Do additional consistency checking when merging local edits.
+   Do additional consistency checking when merging local edits:  check that
+   the annotated source text matches the file on disk, and report an
+   *annotate* error for each line which does not.
+
+``-b``, ``--ignore-whitespace``
+   Applies to ``--verify`` only: a line whose only difference from the local
+   file is whitespace - reindentation, trailing blanks, tabs expanded to
+   spaces - is not reported as a mismatch.  Both texts are compared with
+   leading and trailing whitespace removed and each run of whitespace
+   collapsed to a single space; a line which still differs after that is
+   reported as before.
+   This flag may be necessary, if the ``genhtml --diff-file`` input ignored
+   whitespace differences
 
 ``--log`` *logfile*
    File for annotation-related log messages (useful for debugging).
@@ -87,7 +99,19 @@ annotation specification.
    Cache directory for storing previous results.
 
 ``--verify``
-   Do additional consistency checking when merging local edits.
+   Do additional consistency checking when merging local edits:  check that
+   the annotated source text matches the file on disk, and report an
+   *annotate* error for each line which does not.
+
+``-b``, ``--ignore-whitespace``
+   Applies to ``--verify`` only: a line whose only difference from the local
+   file is whitespace - reindentation, trailing blanks, tabs expanded to
+   spaces - is not reported as a mismatch.  Both texts are compared with
+   leading and trailing whitespace removed and each run of whitespace
+   collapsed to a single space; a line which still differs after that is
+   reported as before.
+   This flag may be necessary, if the ``genhtml --diff-file`` input ignored
+   whitespace differences
 
 ``--log`` *logfile*
    File for annotation-related log messages.

--- a/scripts/annotateutil.pm
+++ b/scripts/annotateutil.pm
@@ -109,21 +109,29 @@ use Cwd qw(abs_path);
 use Fcntl qw(:flock);
 
 use constant {
-              SCRIPT  => 0,
-              CACHE   => 1,
-              LOG     => 2,
-              LOGFILE => 3,
-              VERIFY  => 4,
+              SCRIPT            => 0,
+              CACHE             => 1,
+              LOG               => 2,
+              LOGFILE           => 3,
+              VERIFY            => 4,
+              IGNORE_WHITESPACE => 5,
 };
 
 sub new
 {
     my $class  = shift;
     my $script = shift;
-    my ($cache, $logfile, $verify) = @_;
+    my ($cache, $logfile, $verify, $ignoreWhitespace) = @_;
 
-    my $self = [$script, resolve_cache_dir($cache), undef, $logfile, $verify];
+    my $self = [$script, resolve_cache_dir($cache),
+                undef, $logfile,
+                $verify, $ignoreWhitespace
+    ];
 
+    if ($ignoreWhitespace && !$verify) {
+        lcovutil::ignorable_error($lcovutil::ERROR_USAGE,
+            "$script:  '--ignore-whitespace' has no effect without '--verify'");
+    }
     bless $self, $class;
 
     if ($logfile) {
@@ -223,6 +231,18 @@ sub store_in_cache
         die("unable to store $cache_path");
 }
 
+sub _collapse_whitespace
+{
+    # Leading and trailing whitespace removed, and each run of whitespace
+    #   within the line reduced to one space.  Used only to decide whether two
+    #   lines which are not equal differ in whitespace alone.
+    my $text = shift;
+    $text =~ s/^\s+//;
+    $text =~ s/\s+$//;
+    $text =~ s/\s+/ /g;
+    return $text;
+}
+
 sub verify_annotation
 {
     my ($self, $filepath, $lines) = @_;
@@ -234,11 +254,20 @@ sub verify_annotation
         die('mismatched annotation: local line ' .
             ($lineNo + 1) . " does not exist in annotated data")
             if $lineNo > $#$lines;
-        my $a = $lines->[$lineNo]->[0];
+        my $a    = $lines->[$lineNo]->[0];
+        my $same = $line eq $a;
+        if (!$same && $self->[IGNORE_WHITESPACE]) {
+            # The version in the repo and the version on disk may have been
+            #   reindented, had trailing whitespace stripped, or had tabs
+            #   expanded - none of which changes the code the line contains.
+            #   Compare again with whitespace normalized, and complain only if
+            #   they still differ.
+            $same = _collapse_whitespace($line) eq _collapse_whitespace($a);
+        }
         lcovutil::ignorable_error($lcovutil::ERROR_ANNOTATE_SCRIPT,
                                   "mismatched annotation at $filepath:" .
                                       ($lineNo + 1) . ": '$line' -> '$a'")
-            unless $line eq $a;
+            unless $same;
         ++$lineNo;
     }
     die('mismatched annotation: local file does not contain annotated line ' .

--- a/scripts/gitblame.pm
+++ b/scripts/gitblame.pm
@@ -18,7 +18,7 @@
 #
 #
 # gitblame [--p4] [--prefix path] [--abbrev regexp] [--cache dir] [--verify] \
-#          [--log logfile] [domain] pathname
+#          [-b|--ignore-whitespace] [--log logfile] [domain] pathname
 #
 #   This script runs "git blame" for the specified file and formats the result
 #   to match the diffcov(1) age/ownership annotation specification.
@@ -41,6 +41,10 @@
 #
 #   The '--verify' flag tells the tool to do some additional consistency
 #   checking when merging local edits into the annotated file.
+#
+#   The '-b' (or '--ignore-whitespace') flag applies only to '--verify':  a line
+#   whose only difference from the local file is whitespace - reindentation,
+#   trailing blanks, tabs expanded - is not reported as a mismatch.
 #
 #   The '--log' flag specifies a file where the tool writes various annotation-
 #   related log messages - primarily useful for debugging environment issues.
@@ -68,10 +72,10 @@ use Cwd qw(abs_path);
 use base 'AnnotateBase';
 
 use constant {
-              P4          => 5,
-              ABBREV      => 6,
-              PREFIX      => 7,
-              CHANGELISTS => 8,
+              P4          => 6,
+              ABBREV      => 7,
+              PREFIX      => 8,
+              CHANGELISTS => 9,
 };
 
 sub new
@@ -87,21 +91,23 @@ sub new
     my $standalone = $script eq $0;
     my $help;
     my $verify;
+    my $ignoreWhitespace;
     my $logfile;
 
     if (!GetOptionsFromArray(\@_,
-                             ("p4"       => \$mapP4,
-                              "prefix:s" => \$prefix,
-                              'abbrev:s' => \@abbrev,
-                              'cache:s'  => \$cache_dir,
-                              'verify'   => \$verify,
-                              'log:s'    => \$logfile,
-                              'help'     => \$help)) ||
+                             ("p4"                  => \$mapP4,
+                              "prefix:s"            => \$prefix,
+                              'abbrev:s'            => \@abbrev,
+                              'cache:s'             => \$cache_dir,
+                              'verify'              => \$verify,
+                              'b|ignore-whitespace' => \$ignoreWhitespace,
+                              'log:s'               => \$logfile,
+                              'help'                => \$help)) ||
         (scalar(@_) >= 2) ||
         $help
     ) {
         print(STDERR
-                "usage: $exe [--p4] [--abbrev regexp]* [--cache dir] [--verify] [--log logfile] [domain] pathname\n"
+                "usage: $exe [--p4] [--abbrev regexp]* [--cache dir] [--verify] [-b|--ignore-whitespace] [--log logfile] [domain] pathname\n"
         );
         # exit 0 only when --help was the sole argument; any extra args means error
         exit($help && 0 == scalar(@_) ? 0 : 1) if $standalone;
@@ -114,7 +120,8 @@ sub new
         # else leave domain in place
     }
 
-    my $self = $class->SUPER::new($exe, $cache_dir, $logfile, $verify);
+    my $self = $class->SUPER::new($exe, $cache_dir, $logfile, $verify,
+                                  $ignoreWhitespace);
     # The commit->changelist map is keyed by git commit SHA, which is content-
     # addressed and globally unique, so its git-p4 CL mapping is the same no
     # matter which file references it.  Keep it on $self so the (forking)

--- a/scripts/p4annotate.pm
+++ b/scripts/p4annotate.pm
@@ -22,7 +22,8 @@
 #   This script runs "p4 annotate" for the specified file and formats the result
 #   to match the diffcov(1) 'annotate' callback specification:
 #      use p4annotate;
-#      my $callback = p4annotate->new([--log logfile] [--cache cache_dir] [--verify]);
+#      my $callback = p4annotate->new([--log logfile] [--cache cache_dir] [--verify]
+#                                     [-b|--ignore-whitespace]);
 #      $callback->annotate(filename);
 #
 #   If the '--cache' flag is used:
@@ -39,6 +40,10 @@
 #   The '--verify' flag tells the tool to do some additional consistency
 #   checking when merging local edits into the annotated file.
 #
+#   The '-b' (or '--ignore-whitespace') flag applies only to '--verify':  a line
+#   whose only difference from the local file is whitespace - reindentation,
+#   trailing blanks, tabs expanded - is not reported as a mismatch.
+#
 #   The '--log' flag specifies a file where the tool writes various annotation-
 #   related log messages - primarily useful for debugging environment issues.
 #
@@ -48,7 +53,7 @@
 #   farm environment.
 #
 #   It can also be called directly, as
-#       p4annotate [--log logfile] [--verify] filename
+#       p4annotate [--log logfile] [--verify] [-b|--ignore-whitespace] filename
 
 use strict;
 
@@ -69,26 +74,29 @@ sub new
                            #other arguments are as passed...
     my $logfile;
     my $cache_dir;
-    my $verify     = 0;   # if set, check that we merged local changes correctly
-    my $exe        = File::Basename::basename($script ? $script : $0);
-    my $standalone = $0 eq $script;
+    my $verify = 0;    # if set, check that we merged local changes correctly
+    my $ignoreWhitespace = 0;    # if set, '--verify' tolerates whitespace diffs
+    my $exe              = File::Basename::basename($script ? $script : $0);
+    my $standalone       = $0 eq $script;
 
     if (exists($ENV{LOG_P4ANNOTATE})) {
         $logfile = $ENV{LOG_P4ANNOTATE};
     }
     my $help;
-    if (!Getopt::Long::GetOptionsFromArray(\@_,
-                                           ("verify"  => \$verify,
-                                            "log:s"   => \$logfile,
-                                            'cache:s' => \$cache_dir,
-                                            'help'    => \$help)) ||
+    if (!Getopt::Long::GetOptionsFromArray(
+                                   \@_,
+                                   ("verify"              => \$verify,
+                                    'b|ignore-whitespace' => \$ignoreWhitespace,
+                                    "log:s"               => \$logfile,
+                                    'cache:s'             => \$cache_dir,
+                                    'help'                => \$help)) ||
         (!$standalone && scalar(@_)) ||
         $help
     ) {
-        print(STDERR ($help ? '' : ("unexpected arg: $script " . join(' ', @_))
-              ),
-              "usage: $exe [--log logfile] [--cache dir] [--verify] filename\n"
-        );
+        print
+            (STDERR ($help ? '' : ("unexpected arg: $script " . join(' ', @_))),
+            "usage: $exe [--log logfile] [--cache dir] [--verify] [-b|--ignore-whitespace] filename\n"
+            );
         exit(scalar(@_) == 0 && $help ? 0 : 1) if $standalone;
         return undef;
     }
@@ -103,7 +111,9 @@ sub new
             join(' ', @notset) . " to be set.");
     }
 
-    return $class->SUPER::new($exe, $cache_dir, $logfile, $verify);
+    return
+        $class->SUPER::new($exe, $cache_dir, $logfile, $verify,
+                           $ignoreWhitespace);
 }
 
 sub annotate_callback

--- a/tests/common.mak
+++ b/tests/common.mak
@@ -30,10 +30,10 @@ IS_GIT := $(shell git -C $(TOPDIR) rev-parse 2>&1 > /dev/null ; if [ 0 -eq $$? ]
 IS_P4 = $(shell p4 have ... 2>&1 > /dev/null ; if [ 0 -eq $$? ]; then echo 1 ; else echo 0 ; fi)
 
 ifeq (1,$(IS_GIT))
-ANNOTATE_SCRIPT=$(SCRIPTDIR)/gitblame.pm,--verify
+ANNOTATE_SCRIPT=$(SCRIPTDIR)/gitblame.pm,--verify,-b
 VERSION_SCRIPT=$(SCRIPTDIR)/gitversion.pm
 else
-ANNOTATE_SCRIPT=$(SCRIPTDIR)/p4annotate.pm,--verify
+ANNOTATE_SCRIPT=$(SCRIPTDIR)/p4annotate.pm,--verify,-b
 VERSION_SCRIPT=$(SCRIPTDIR)/P4version.pm,--local-edit,$(ROOT_DIR)
 endif
 

--- a/tests/scripts/gitblame_test.sh
+++ b/tests/scripts/gitblame_test.sh
@@ -23,6 +23,10 @@
 #  14.  --log flag: log file written and contains expected content
 #  15.  Multi-author file: two different commit hashes, two different owners
 #  16.  --p4 flag: CL extracted from git-p4 commit log comment
+#  17.  --verify without -b reports a whitespace-only mismatch
+#  18.  --verify -b tolerates the same whitespace-only mismatch
+#  19.  --verify --ignore-whitespace still reports a non-whitespace mismatch
+#  20.  -b without --verify is a usage error (both spellings)
 #
 
 set +x
@@ -46,6 +50,11 @@ if [ ! -x "$GITBLAME" ] ; then
 fi
 # Prepend coverage wrapper when active (same pattern used by other test scripts)
 [ -n "$COVER" ] && GITBLAME="$COVER $GITBLAME"
+
+# When coverage is active, $COVER is "perl -MDevel::Cover=... " so use it as the
+# perl interpreter for the direct .pm invocations below, too.
+PERL="${COVER:-perl}"
+LCOV_LIB="$LCOV_HOME/lib"
 
 # Require git
 if ! which git >/dev/null 2>&1 ; then
@@ -445,6 +454,147 @@ elif ! echo "$OUTPUT" | grep -q '^99887|' ; then
 $OUTPUT"
 else
     pass "Test 16: --p4 extracts CL number from git-p4 commit message"
+fi
+
+# -----------------------------------------------------------------------
+# Tests 17-19: -b / --ignore-whitespace tolerates whitespace-only mismatches
+#   'git blame' reports the working-tree text of a line, so the only way the
+#   annotated text can differ from the file on disk is a transformation the
+#   callback itself applies:  gitblame.pm strips a trailing CR from each blame
+#   line, whereas 'verify_annotation' reads the local file and only chomps the
+#   newline.  So a file committed with CRLF line endings produces exactly one
+#   kind of difference - a trailing CR - which is whitespace and nothing else.
+#   That makes it the end-to-end case for these two flags.
+#   These call the module directly rather than the 'gitblame' driver:  a
+#   mismatch is reported through lcovutil::ignorable_error, which only exists
+#   once some tool has loaded lcovutil.
+# -----------------------------------------------------------------------
+REPO17=$(make_git_repo)
+printf 'int main() {\r\n    return 0;\r\n}\r\n' > "$REPO17/crlf.c"
+git -C "$REPO17" add crlf.c
+fixed_commit "$REPO17" "crlf test" "2024-02-01 08:00:00 +0000"
+
+# Usage: run_verify <flag>...  -- sets OUTPUT and RC
+run_verify() {
+    OUTPUT=$($PERL -I"$LCOV_LIB" -I"$SCRIPT_DIR" -e \
+        'use lcovutil; use gitblame; use annotateutil qw(call_annotate);
+         call_annotate("gitblame", "gitblame", @ARGV);' -- "$@" 2>&1)
+    RC=$?
+}
+
+# ---- Test 17: without -b, the trailing CR is reported as a mismatch
+run_verify --verify "$REPO17/crlf.c"
+if [ $RC -eq 0 ] ; then
+    fail "Test 17 verify-no-b: expected non-zero exit, got 0; output: $OUTPUT"
+elif ! echo "$OUTPUT" | grep -q 'mismatched annotation at .*crlf\.c:1' ; then
+    fail "Test 17 verify-no-b: expected mismatch message; got: $OUTPUT"
+else
+    pass "Test 17: --verify without -b reports a whitespace-only mismatch"
+fi
+
+# ---- Test 18: with -b, the same input is accepted
+run_verify --verify -b "$REPO17/crlf.c"
+if [ $RC -ne 0 ] ; then
+    fail "Test 18 verify-b: expected exit 0, got $RC; output: $OUTPUT"
+elif echo "$OUTPUT" | grep -q 'mismatched annotation' ; then
+    fail "Test 18 verify-b: whitespace-only difference still reported: $OUTPUT"
+elif [ 3 -ne "$(echo "$OUTPUT" | grep -c '|')" ] ; then
+    fail "Test 18 verify-b: expected 3 annotated lines; got: $OUTPUT"
+else
+    pass "Test 18: --verify -b tolerates a whitespace-only mismatch"
+fi
+
+rm -rf "$REPO17"
+
+# ---- Test 19: a difference which survives whitespace normalization is still
+#      reported.  'git blame' reports the working-tree text of every line, so
+#      no repo state can make the annotated text differ from the file by
+#      anything but the CR above; call AnnotateBase::verify_annotation directly
+#      with annotation data which differs in a token instead.  Three lines, two
+#      of which differ only in whitespace and must stay silent, so the count is
+#      asserted and not just the presence of the message.
+TMP19=$(mktemp --suffix=.c)
+printf 'int  main( )  {\n\treturn 0;   \n}\n' > "$TMP19"
+OUTPUT=$($PERL -I"$LCOV_LIB" -I"$SCRIPT_DIR" -e \
+    'use lcovutil; use annotateutil;
+     $lcovutil::ignore[$lcovutil::ERROR_ANNOTATE_SCRIPT] = 1;   # report them all
+     my $self = AnnotateBase->new("probe", undef, undef, 1, 1);
+     $self->verify_annotation($ARGV[0],
+                              [map({ [$_] } ("int  main( )  {",
+                                             "    return 1;",
+                                             "}"))]);' -- "$TMP19" 2>&1)
+RC=$?
+rm -f "$TMP19"
+COUNT=$(echo "$OUTPUT" | grep -c 'mismatched annotation')
+if [ $RC -ne 0 ] ; then
+    fail "Test 19 real-diff: expected exit 0 (error ignored), got $RC; output: $OUTPUT"
+elif [ "$COUNT" -ne 1 ] ; then
+    fail "Test 19 real-diff: expected exactly 1 mismatch, got $COUNT; output: $OUTPUT"
+elif ! echo "$OUTPUT" | grep -q "mismatched annotation at .*:2: " ; then
+    fail "Test 19 real-diff: expected the line 2 mismatch; got: $OUTPUT"
+else
+    pass "Test 19: --ignore-whitespace still reports a non-whitespace mismatch"
+fi
+
+# -----------------------------------------------------------------------
+# Test 20: -b affects only the --verify comparison, so on its own it does
+#   nothing - AnnotateBase::new reports that as a 'usage' error rather than
+#   silently ignoring the flag.  Both spellings, and both arms of the error:
+#   fatal by default, and a warning which still annotates when 'usage' is
+#   ignored.
+# -----------------------------------------------------------------------
+REPO20=$(make_git_repo)
+printf 'orphan flag line\n' > "$REPO20/orphan.c"
+git -C "$REPO20" add orphan.c
+fixed_commit "$REPO20" "orphan flag test" "2024-03-01 08:00:00 +0000"
+
+# Usage: run_orphan <ignore-usage 0|1> <flag>...  -- sets OUTPUT and RC
+run_orphan() {
+    local ignore="$1" ; shift
+    OUTPUT=$($PERL -I"$LCOV_LIB" -I"$SCRIPT_DIR" -e \
+        'use lcovutil; use gitblame; use annotateutil qw(call_annotate);
+         $lcovutil::ignore[$lcovutil::ERROR_USAGE] = 1 if $ARGV[0];
+         shift(@ARGV);
+         call_annotate("gitblame", "gitblame", @ARGV);' -- "$ignore" "$@" 2>&1)
+    RC=$?
+}
+
+BAD=""
+for flag in -b --ignore-whitespace ; do
+    # ---- default: the usage error is fatal and nothing is annotated
+    run_orphan 0 $flag "$REPO20/orphan.c"
+    if [ $RC -eq 0 ] ; then
+        BAD="$BAD $flag:expected-nonzero"
+    elif ! echo "$OUTPUT" | grep -q "ERROR: (usage).*'--ignore-whitespace' has no effect without '--verify'" ; then
+        BAD="$BAD $flag:no-usage-error"
+    elif echo "$OUTPUT" | grep -q 'orphan flag line' ; then
+        BAD="$BAD $flag:annotated-anyway"
+    fi
+
+    # ---- '--ignore-errors usage': a warning, and annotation proceeds
+    run_orphan 1 $flag "$REPO20/orphan.c"
+    if [ $RC -ne 0 ] ; then
+        BAD="$BAD $flag:ignored-still-fatal"
+    elif ! echo "$OUTPUT" | grep -q "WARNING: (usage).*'--ignore-whitespace' has no effect" ; then
+        BAD="$BAD $flag:no-usage-warning"
+    elif ! echo "$OUTPUT" | grep -q '|orphan flag line' ; then
+        BAD="$BAD $flag:no-annotation"
+    fi
+done
+
+# ...and no message at all when --verify is present
+run_orphan 0 --verify -b "$REPO20/orphan.c"
+rm -rf "$REPO20"
+if [ $RC -ne 0 ] ; then
+    BAD="$BAD with-verify:nonzero"
+elif echo "$OUTPUT" | grep -q '(usage)' ; then
+    BAD="$BAD with-verify:unexpected-message"
+fi
+
+if [ -n "$BAD" ] ; then
+    fail "Test 20 orphan-b:$BAD; last output: $OUTPUT"
+else
+    pass "Test 20: -b without --verify reports a 'usage' error"
 fi
 
 # -----------------------------------------------------------------------

--- a/tests/scripts/p4annotate_test.sh
+++ b/tests/scripts/p4annotate_test.sh
@@ -17,7 +17,8 @@
 # Tests 5-10:  Constructor argument parsing       (args_check.sh)
 # Tests 11-13: --help / usage message             (help_check.sh)
 # Tests 14-17: Symlink / path normalisation       (symlink_check.sh)
-# Tests 18-34: End-to-end annotation output       (annotate_check.sh)
+# Tests 18-35: End-to-end annotation output       (annotate_check.sh)
+# Tests 36-39: -b / --ignore-whitespace
 #
 
 set +x
@@ -1114,6 +1115,145 @@ elif ! echo "$OUTPUT" | grep -qF "result=$NONEXIST" ; then
     fail "Test 35 nonexistent-path: expected path unchanged; got: $OUTPUT"
 else
     pass "Test 35: normalize_path returns original for non-existent path"
+fi
+
+# ===========================================================================
+# Tests 36-39: -b / --ignore-whitespace
+#   The annotated text comes from the depot version of the file, and the local
+#   file may have been reindented or had trailing blanks stripped since; -b
+#   says that such a line is not a mismatch, whereas one which differs by
+#   anything else still is.
+#   These go through the module (with lcovutil loaded) rather than the
+#   'p4annotate' driver, because a mismatch is reported through
+#   lcovutil::ignorable_error, which only exists once a tool has loaded
+#   lcovutil.
+# ===========================================================================
+LCOV_LIB="$LCOV_HOME/lib"
+
+# Usage: run_verify <flag>...  -- sets OUTPUT and RC
+run_verify() {
+    OUTPUT=$($PERL -I"$LCOV_LIB" -I"$SCRIPT_DIR" -e \
+        'use lcovutil; use p4annotate; use annotateutil qw(call_annotate);
+         call_annotate("p4annotate", "p4annotate", @ARGV);' -- "$@" 2>&1)
+    RC=$?
+}
+
+export P4MOCK_FILES="in_p4"
+unset P4MOCK_HAVE P4MOCK_OPENED
+
+# The depot text is indented with 4 spaces and has no trailing blanks; the
+#   local file uses a tab and has trailing blanks.  Same tokens, different
+#   whitespace, on every line.
+AMOCK=$(mk_annotate << 'EOF'
+900: alice 2024/10/01     int x = foo(a, b);
+901: alice 2024/10/01     return x;
+EOF
+)
+export P4MOCK_ANNOTATE="$AMOCK"
+TGT=$(mk_target "\tint  x = foo(a, b);\nreturn x;   \n")
+
+# ---------------------------------------------------------------------------
+# Test 36: --verify without -b reports each whitespace-only difference
+# ---------------------------------------------------------------------------
+run_verify --verify "$TGT"
+if [ $RC -eq 0 ] ; then
+    fail "Test 36 verify-no-b: expected non-zero exit, got 0; output: $OUTPUT"
+elif ! echo "$OUTPUT" | grep -q 'mismatched annotation at .*:1' ; then
+    fail "Test 36 verify-no-b: expected a mismatch message; got: $OUTPUT"
+else
+    pass "Test 36: --verify without -b reports whitespace-only mismatches"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 37: --verify -b accepts the same input, and still emits the depot text
+# ---------------------------------------------------------------------------
+run_verify --verify -b "$TGT"
+if [ $RC -ne 0 ] ; then
+    fail "Test 37 verify-b: expected exit 0, got $RC; output: $OUTPUT"
+elif echo "$OUTPUT" | grep -q 'mismatched annotation' ; then
+    fail "Test 37 verify-b: whitespace-only difference still reported: $OUTPUT"
+elif ! echo "$OUTPUT" | grep -q '^900|alice|.*|    int x = foo(a, b);$' ; then
+    fail "Test 37 verify-b: expected the depot text unchanged; got: $OUTPUT"
+else
+    pass "Test 37: --verify -b tolerates whitespace-only mismatches"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 38: a difference which survives normalization is still reported, and
+#          only that line is.  Line 1 differs in a token; line 2 differs only
+#          in whitespace and must stay silent.
+# ---------------------------------------------------------------------------
+rm -f "$TGT"
+TGT=$(mk_target "\tint  y = foo(a, b);\nreturn x;   \n")
+run_verify --verify --ignore-whitespace "$TGT"
+COUNT=$(echo "$OUTPUT" | grep -c 'mismatched annotation')
+if [ $RC -eq 0 ] ; then
+    fail "Test 38 real-diff: expected non-zero exit, got 0; output: $OUTPUT"
+elif [ "$COUNT" -ne 1 ] ; then
+    fail "Test 38 real-diff: expected exactly 1 mismatch, got $COUNT; output: $OUTPUT"
+elif ! echo "$OUTPUT" | grep -q 'mismatched annotation at .*:1: ' ; then
+    fail "Test 38 real-diff: expected the line 1 mismatch; got: $OUTPUT"
+else
+    pass "Test 38: --ignore-whitespace still reports a non-whitespace mismatch"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 39: -b affects only the --verify comparison, so on its own it does
+#          nothing - AnnotateBase::new reports that as a 'usage' error rather
+#          than silently ignoring the flag.  Both spellings, and both arms of
+#          the error: fatal by default, and a warning which still annotates
+#          when 'usage' is ignored.
+# ---------------------------------------------------------------------------
+rm -f "$TGT"
+TGT=$(mk_target "    int x = foo(a, b);\n    return x;\n")
+
+# Usage: run_orphan <ignore-usage 0|1> <flag>...  -- sets OUTPUT and RC
+run_orphan() {
+    local ignore="$1" ; shift
+    OUTPUT=$($PERL -I"$LCOV_LIB" -I"$SCRIPT_DIR" -e \
+        'use lcovutil; use p4annotate; use annotateutil qw(call_annotate);
+         $lcovutil::ignore[$lcovutil::ERROR_USAGE] = 1 if $ARGV[0];
+         shift(@ARGV);
+         call_annotate("p4annotate", "p4annotate", @ARGV);' -- "$ignore" "$@" 2>&1)
+    RC=$?
+}
+
+BAD=""
+for flag in -b --ignore-whitespace ; do
+    # ---- default: the usage error is fatal and nothing is annotated
+    run_orphan 0 $flag "$TGT"
+    if [ $RC -eq 0 ] ; then
+        BAD="$BAD $flag:expected-nonzero"
+    elif ! echo "$OUTPUT" | grep -q "ERROR: (usage).*'--ignore-whitespace' has no effect without '--verify'" ; then
+        BAD="$BAD $flag:no-usage-error"
+    elif echo "$OUTPUT" | grep -q '^900|' ; then
+        BAD="$BAD $flag:annotated-anyway"
+    fi
+
+    # ---- '--ignore-errors usage': a warning, and annotation proceeds
+    run_orphan 1 $flag "$TGT"
+    if [ $RC -ne 0 ] ; then
+        BAD="$BAD $flag:ignored-still-fatal"
+    elif ! echo "$OUTPUT" | grep -q "WARNING: (usage).*'--ignore-whitespace' has no effect" ; then
+        BAD="$BAD $flag:no-usage-warning"
+    elif ! echo "$OUTPUT" | grep -q '^900|' ; then
+        BAD="$BAD $flag:no-annotation"
+    fi
+done
+
+# ...and no message at all when --verify is present
+run_orphan 0 --verify -b "$TGT"
+if [ $RC -ne 0 ] ; then
+    BAD="$BAD with-verify:nonzero"
+elif echo "$OUTPUT" | grep -q '(usage)' ; then
+    BAD="$BAD with-verify:unexpected-message"
+fi
+rm -f "$TGT" "$AMOCK" ; unset P4MOCK_ANNOTATE P4MOCK_FILES
+
+if [ -n "$BAD" ] ; then
+    fail "Test 39 orphan-b:$BAD; last output: $OUTPUT"
+else
+    pass "Test 39: -b without --verify reports a 'usage' error"
 fi
 
 # ===========================================================================


### PR DESCRIPTION
This is necessary if we try to '--verify' annotations on a line which differed only in whitespace and the '--diff-file' argument was whitespace insensitive.