### PR TITLE
Fix codespell CI / `scripts/analyzeInfoFiles`: Fix typo "opend" 

### DIFF
--- a/scripts/analyzeInfoFiles
+++ b/scripts/analyzeInfoFiles
@@ -435,7 +435,7 @@ foreach my $infoFile (@ARGV) {
         push(@infoFileArray, $infoFile);
     } else {
         open(INPUT, "<", $infoFile) or
-            die("Error: unable to opend $infoFile: $!\n");
+            die("Error: unable to open $infoFile: $!\n");
         while (<INPUT>) {
             chomp($_);
             next


### PR DESCRIPTION
Uncovered by codespell CI 6 hours ago at https://github.com/hartwork/lcov-fork/actions/runs/32492119955/job/96801967313#step:4:19

Related: https://github.com/codespell-project/codespell/pull/3621
